### PR TITLE
fix: MSVC compiler warnings fixes.

### DIFF
--- a/cpp/lib/include/opendnp3/link/ILinkListener.h
+++ b/cpp/lib/include/opendnp3/link/ILinkListener.h
@@ -34,13 +34,13 @@ class ILinkListener
 {
 public:
     /// Called when a the reset/unreset status of the link layer changes
-    virtual void OnStateChange(LinkStatus value, LinkStateChangeSource source) {}
+    virtual void OnStateChange(LinkStatus /*value*/, LinkStateChangeSource /*source*/) {}
 
     /// Called when a link-layer frame is received from an unknown destination address
-    virtual void OnUnknownDestinationAddress(uint16_t destination) {}
+    virtual void OnUnknownDestinationAddress(uint16_t /*destination*/) {}
 
     /// Called when a link-layer frame is received from an unknown source address
-    virtual void OnUnknownSourceAddress(uint16_t source) {}
+    virtual void OnUnknownSourceAddress(uint16_t /*source*/) {}
 
     /// Called when the keep alive timer elapses. This doesn't denote a keep-alive failure, it's just a notification
     virtual void OnKeepAliveInitiated() {}

--- a/cpp/lib/include/opendnp3/link/LinkConfig.h
+++ b/cpp/lib/include/opendnp3/link/LinkConfig.h
@@ -38,7 +38,7 @@ struct LinkConfig
     LinkConfig() = delete;
 
     LinkConfig(
-        bool isMaster, uint16_t localAddr, uint16_t remoteAddr, TimeDuration timeout, TimeDuration keepAliveTimeout, const StatisticsChangeHandler_t& statisticsChangeHandler)
+        bool isMaster, uint16_t localAddr, uint16_t remoteAddr, TimeDuration timeout, TimeDuration keepAliveTimeout)
         :
           IsMaster(isMaster),
           LocalAddr(localAddr),
@@ -49,7 +49,7 @@ struct LinkConfig
     }
 
     [[deprecated("Use LinkConfig(bool) instead.")]]
-    LinkConfig(bool isMaster, bool useConfirms)
+    LinkConfig(bool isMaster, bool /*useConfirms*/)
         :
           IsMaster(isMaster),
           LocalAddr(isMaster ? 1 : 1024),

--- a/cpp/lib/include/opendnp3/master/IMasterApplication.h
+++ b/cpp/lib/include/opendnp3/master/IMasterApplication.h
@@ -44,15 +44,15 @@ public:
     virtual ~IMasterApplication() {}
 
     /// Called when a response or unsolicited response is receive from the outstation
-    virtual void OnReceiveIIN(const IINField& iin) {}
+    virtual void OnReceiveIIN(const IINField& /*iin*/) {}
 
     /// Task start notification
-    virtual bool OnTaskStart(MasterTaskType type, TaskId id) {
+    virtual bool OnTaskStart(MasterTaskType /*type*/, TaskId /*id*/) {
         return true;
     }
 
     /// Task completion notification
-    virtual void OnTaskComplete(const TaskInfo& info) {}
+    virtual void OnTaskComplete(const TaskInfo& /*info*/) {}
 
     /// Called when the application layer is opened
     virtual void OnOpen() {}
@@ -69,9 +69,9 @@ public:
     /// Configure the request headers for assign class. Only called if
     /// "AssignClassDuringStartup" returns true
     /// The user only needs to call the function for each header type to be written
-    virtual void ConfigureAssignClassRequest(const WriteHeaderFunT& fun) {}
+    virtual void ConfigureAssignClassRequest(const WriteHeaderFunT& /*fun*/) {}
 
-    virtual void OnChannelReservationChanged(bool isBackup) {}
+    virtual void OnChannelReservationChanged(bool /*isBackup*/) {}
 };
 
 } // namespace opendnp3

--- a/cpp/lib/include/opendnp3/outstation/DefaultOutstationApplication.h
+++ b/cpp/lib/include/opendnp3/outstation/DefaultOutstationApplication.h
@@ -57,7 +57,7 @@ public:
     {
         return false;
     }
-    virtual bool WriteTimeAndInterval(const ICollection<Indexed<TimeAndInterval>>& values) override
+    virtual bool WriteTimeAndInterval(const ICollection<Indexed<TimeAndInterval>>& /*values*/) override
     {
         return false;
     }
@@ -66,7 +66,7 @@ public:
     {
         return true;
     }
-    virtual void RecordClassAssignment(AssignClassType type, PointClass clazz, uint16_t start, uint16_t stop) override
+    virtual void RecordClassAssignment(AssignClassType /*type*/, PointClass /*clazz*/, uint16_t /*start*/, uint16_t /*stop*/) override
     {
     }
 

--- a/cpp/lib/include/opendnp3/outstation/IOutstationApplication.h
+++ b/cpp/lib/include/opendnp3/outstation/IOutstationApplication.h
@@ -54,7 +54,7 @@ public:
     /// @return boolean value indicating if the time value supplied was accepted. Returning
     /// false will cause the outstation to set IIN 2.3 (PARAM_ERROR) in its response.
     /// The outstation should clear its NEED_TIME field when handling this response
-    virtual bool WriteAbsoluteTime(const UTCTimestamp& timestamp)
+    virtual bool WriteAbsoluteTime(const UTCTimestamp& /*timestamp*/)
     {
         return false;
     }
@@ -72,7 +72,7 @@ public:
     /// behavior is desired
     /// @return boolean value indicating if the values supplied were accepted. Returning
     /// false will cause the outstation to set IIN 2.3 (PARAM_ERROR) in its response.
-    virtual bool WriteTimeAndInterval(const ICollection<Indexed<TimeAndInterval>>& values)
+    virtual bool WriteTimeAndInterval(const ICollection<Indexed<TimeAndInterval>>& /*values*/)
     {
         return false;
     }
@@ -89,7 +89,7 @@ public:
     /// The type and range are pre-validated against the outstation's database
     /// and class assignments are automatically applied internally.
     /// This callback allows user code to persist the changes to non-volatile memory
-    virtual void RecordClassAssignment(AssignClassType type, PointClass clazz, uint16_t start, uint16_t stop) {}
+    virtual void RecordClassAssignment(AssignClassType /*type*/, PointClass /*clazz*/, uint16_t /*start*/, uint16_t /*stop*/) {}
 
     /// Returns the application-controlled IIN field
     virtual ApplicationIIN GetApplicationIIN() const
@@ -135,7 +135,7 @@ public:
     /// @param num_class1 number of Class 1 events remaining in the event buffer after processing the confirm
     /// @param num_class2 number of Class 2 events remaining in the event buffer after processing the confirm
     /// @param num_class3 number of Class 3 events remaining in the event buffer after processing the confirm
-    virtual void OnConfirmProcessed(bool is_unsolicited, uint32_t num_class1, uint32_t num_class2, uint32_t num_class3) {}
+    virtual void OnConfirmProcessed(bool /*is_unsolicited*/, uint32_t /*num_class1*/, uint32_t /*num_class2*/, uint32_t /*num_class3*/) {}
 
     virtual ~IOutstationApplication() = default;
 };

--- a/cpp/lib/include/opendnp3/outstation/StaticTypeBitfield.h
+++ b/cpp/lib/include/opendnp3/outstation/StaticTypeBitfield.h
@@ -38,7 +38,7 @@ struct StaticTypeBitField
 
     static StaticTypeBitField AllTypes()
     {
-        return StaticTypeBitField(~0);
+        return StaticTypeBitField(static_cast<uint16_t>(~0));
     }
 
     bool IsSet(StaticTypeBitmask type) const


### PR DESCRIPTION
Fix warning "C4100" "unreferenced formal parameter" of msvc compiler.