### PR TITLE
Task behaviour changed to respect retryCount; Made changes to distinguish between failing to open a communication channel and task timeouts indicating failure

### DIFF
--- a/cpp/lib/include/opendnp3/master/IMasterApplication.h
+++ b/cpp/lib/include/opendnp3/master/IMasterApplication.h
@@ -33,7 +33,13 @@
 namespace opendnp3
 {
 
-typedef std::function<void(const Header&)> WriteHeaderFunT;
+using WriteHeaderFunT = std::function<void(const Header&)>;
+
+enum class MasterStatus
+{
+    Working,
+    Error
+};
 
 /**
  * Interface for all master application callback info except for measurement values.
@@ -41,7 +47,7 @@ typedef std::function<void(const Header&)> WriteHeaderFunT;
 class IMasterApplication : public ILinkListener, public IUTCTimeSource
 {
 public:
-    virtual ~IMasterApplication() {}
+    virtual ~IMasterApplication() = default;
 
     /// Called when a response or unsolicited response is receive from the outstation
     virtual void OnReceiveIIN(const IINField& /*iin*/) {}
@@ -72,6 +78,8 @@ public:
     virtual void ConfigureAssignClassRequest(const WriteHeaderFunT& /*fun*/) {}
 
     virtual void OnChannelReservationChanged(bool /*isBackup*/) {}
+
+    virtual void OnMasterStatusChanged(MasterStatus /*status*/) {}
 };
 
 } // namespace opendnp3

--- a/cpp/lib/src/channel/DNP3Channel.cpp
+++ b/cpp/lib/src/channel/DNP3Channel.cpp
@@ -35,13 +35,12 @@ DNP3Channel::DNP3Channel(const Logger& logger,
                          const std::shared_ptr<exe4cpp::StrandExecutor>& executor,
                          std::shared_ptr<IOHandlersManager> iohandlersManager,
                          std::shared_ptr<IResourceManager> manager)
-    :
-      logger(logger),
-      executor(executor),
-      scheduler(std::make_shared<MasterSchedulerBackend>(executor)),
-      iohandlersManager(std::move(iohandlersManager)),
-      manager(std::move(manager)),
-      resources(ResourceManager::Create())
+    : logger(logger)
+    , executor(executor)
+    , scheduler(std::make_shared<MasterSchedulerBackend>(executor))
+    , iohandlersManager(std::move(iohandlersManager))
+    , manager(std::move(manager))
+    , resources(ResourceManager::Create())
 {
     this->iohandlersManager->ChannelChanging.connect([masterScheduler = this->scheduler](const bool pause) {
         if (masterScheduler)

--- a/cpp/lib/src/channel/DNP3Channel.h
+++ b/cpp/lib/src/channel/DNP3Channel.h
@@ -32,10 +32,12 @@ class DNP3Channel final : public IChannel, public std::enable_shared_from_this<D
 {
 
 public:
-    DNP3Channel(const Logger& logger,
-                const std::shared_ptr<exe4cpp::StrandExecutor>& executor,
-                std::shared_ptr<IOHandlersManager> iohandlersManager,
-                std::shared_ptr<IResourceManager> manager);
+    DNP3Channel(
+        const Logger& logger,
+        const std::shared_ptr<exe4cpp::StrandExecutor>& executor,
+        std::shared_ptr<IOHandlersManager> iohandlersManager,
+        std::shared_ptr<IResourceManager> manager
+    );
 
     static std::shared_ptr<DNP3Channel> Create(const Logger& logger,
                                                const std::shared_ptr<exe4cpp::StrandExecutor>& executor,

--- a/cpp/lib/src/channel/IOHandler.cpp
+++ b/cpp/lib/src/channel/IOHandler.cpp
@@ -128,7 +128,7 @@ bool IOHandler::BeginTransmit(const std::shared_ptr<ILinkSession>& session, cons
     return false;
 }
 
-bool IOHandler::Prepare(NewChannelOpenedCallback_t channelOpenedCallback)
+bool IOHandler::Prepare(const NewChannelOpenedCallback_t& channelOpenedCallback)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
     if (_openingChannel)

--- a/cpp/lib/src/channel/IOHandler.h
+++ b/cpp/lib/src/channel/IOHandler.h
@@ -64,7 +64,7 @@ public:
     bool BeginTransmit(const std::shared_ptr<ILinkSession>& session, const ser4cpp::rseq_t& data);
 
     // Begin sending messages to the context
-    bool Prepare(NewChannelOpenedCallback_t channelOpenedCallback = nullptr);
+    bool Prepare(const NewChannelOpenedCallback_t& channelOpenedCallback = nullptr);
 
     // Stop sending messages to this session
     void ConditionalClose();

--- a/cpp/lib/src/channel/IOHandlersManager.cpp
+++ b/cpp/lib/src/channel/IOHandlersManager.cpp
@@ -191,6 +191,7 @@ namespace opendnp3
         if (result)
         {
             _currentChannel->ConditionalClose();
+            _channelStateChanged(true);
         }
         return result;
     }
@@ -204,7 +205,7 @@ namespace opendnp3
 
         FORMAT_LOG_BLOCK(
             _logger,
-            flags::DBG,
+            flags::WARN,
             R"(%strying to switch to %s connection)",
             onFail ? "connection error, " : "",
             !_backupChannelUsed ? "primary" : "backup"
@@ -228,14 +229,7 @@ namespace opendnp3
                 }
                 self->_currentChannel = newChannel;
                 self->ChannelChanging(false);
-                if (self->_channelStateChanged)
-                {
-                    self->_channelStateChanged(false);
-                }
-
                 self->ChannelReservationChanged(self->_backupChannelUsed);
-                (self->_backupChannelUsed ? self->_backupChannelState : self->_primaryChannelState) = Working;
-                (!self->_backupChannelUsed ? self->_backupChannelState : self->_primaryChannelState) = Undecided;
             };
             if (newChannel->Prepare(handler))
             {
@@ -291,6 +285,9 @@ namespace opendnp3
             if (isDataReading)
             {
                 ++_succeededReadingCount;
+                (_backupChannelUsed ? _backupChannelState : _primaryChannelState) = Working;
+                (!_backupChannelUsed ? _backupChannelState : _primaryChannelState) = Undecided;
+                _channelStateChanged(false);
             }
         }
         else
@@ -302,6 +299,11 @@ namespace opendnp3
             }
 
             (_backupChannelUsed ? _backupChannelState : _primaryChannelState) = Error;
+            if (_primaryChannelState == Error && _backupChannelState == Error) {
+                if (_channelStateChanged) {
+                    _channelStateChanged(true);
+                }
+            }
             _backupChannelUsed = !_backupChannelUsed;
             trySwitchChannel(true);
         }

--- a/cpp/lib/src/channel/IOHandlersManager.cpp
+++ b/cpp/lib/src/channel/IOHandlersManager.cpp
@@ -293,16 +293,15 @@ namespace opendnp3
         else
         {
             _succeededReadingCount = 0;
-            if (!_backupSettings)
-            {
-                return;
-            }
-
             (_backupChannelUsed ? _backupChannelState : _primaryChannelState) = Error;
             if (_primaryChannelState == Error && _backupChannelState == Error) {
                 if (_channelStateChanged) {
                     _channelStateChanged(true);
                 }
+            }
+            if (!_backupSettings)
+            {
+                return;
             }
             _backupChannelUsed = !_backupChannelUsed;
             trySwitchChannel(true);

--- a/cpp/lib/src/channel/IOHandlersManager.h
+++ b/cpp/lib/src/channel/IOHandlersManager.h
@@ -93,7 +93,7 @@ namespace opendnp3
         Callback_t _channelStateChanged;
         std::shared_ptr<exe4cpp::StrandExecutor> _executor;
         ChannelState _primaryChannelState{ Error };
-        ChannelState _backupChannelState{ Error };
+        ChannelState _backupChannelState{ Undecided };
     };
 
 } // namespace opendnp3

--- a/cpp/lib/src/master/CommandTask.cpp
+++ b/cpp/lib/src/master/CommandTask.cpp
@@ -31,81 +31,82 @@
 namespace opendnp3
 {
 
-std::shared_ptr<IMasterTask> CommandTask::CreateDirectOperate(const std::shared_ptr<TaskContext>& context,
-                                                              CommandSet&& set,
-                                                              IndexQualifierMode mode,
-                                                              IMasterApplication& app,
-                                                              const CommandResultCallbackT& callback,
-                                                              const Timestamp& startExpiration,
-                                                              const TaskConfig& config,
-                                                              Logger logger)
-{
-    auto task
-        = std::make_shared<CommandTask>(context, std::move(set), mode, app, callback, startExpiration, config, logger);
+std::shared_ptr<IMasterTask> CommandTask::CreateDirectOperate(
+    const std::shared_ptr<TaskContext>& context,
+    CommandSet&& set,
+    IndexQualifierMode mode,
+    IMasterApplication& app,
+    const CommandResultCallbackT& callback,
+    const TaskConfig& config,
+    const TaskBehavior& taskBehavior,
+    Logger logger
+) {
+    auto task = std::make_shared<CommandTask>(context, std::move(set), mode, app, callback, config, taskBehavior, logger);
     task->LoadDirectOperate();
     return task;
 }
 
-std::shared_ptr<IMasterTask> CommandTask::CreateSelectAndOperate(const std::shared_ptr<TaskContext>& context,
-                                                                 CommandSet&& set,
-                                                                 IndexQualifierMode mode,
-                                                                 IMasterApplication& app,
-                                                                 const CommandResultCallbackT& callback,
-                                                                 const Timestamp& startExpiration,
-                                                                 const TaskConfig& config,
-                                                                 Logger logger)
-{
-    auto task
-        = std::make_shared<CommandTask>(context, std::move(set), mode, app, callback, startExpiration, config, logger);
+std::shared_ptr<IMasterTask> CommandTask::CreateSelectAndOperate(
+    const std::shared_ptr<TaskContext>& context,
+    CommandSet&& set,
+    IndexQualifierMode mode,
+    IMasterApplication& app,
+    const CommandResultCallbackT& callback,
+    const TaskConfig& config,
+    const TaskBehavior& taskBehavior,
+    Logger logger
+) {
+    auto task = std::make_shared<CommandTask>(context, std::move(set), mode, app, callback, config, taskBehavior, logger);
     task->LoadSelectAndOperate();
     return task;
 }
 
-std::shared_ptr<IMasterTask> CommandTask::CreateSelect(const std::shared_ptr<TaskContext>& context,
-                                                       CommandSet&& set,
-                                                       IndexQualifierMode mode,
-                                                       IMasterApplication& app,
-                                                       const CommandResultCallbackT& callback,
-                                                       const Timestamp& startExpiration,
-                                                       const TaskConfig& config,
-                                                       Logger logger)
-{
-    auto task
-        = std::make_shared<CommandTask>(context, std::move(set), mode, app, callback, startExpiration, config, logger);
+std::shared_ptr<IMasterTask> CommandTask::CreateSelect(
+    const std::shared_ptr<TaskContext>& context,
+    CommandSet&& set,
+    IndexQualifierMode mode,
+    IMasterApplication& app,
+    const CommandResultCallbackT& callback,
+    const TaskConfig& config,
+    const TaskBehavior& taskBehavior,
+    Logger logger
+) {
+    auto task = std::make_shared<CommandTask>(context, std::move(set), mode, app, callback, config, taskBehavior, logger);
     task->LoadSelect();
     return task;
 }
 
-std::shared_ptr<IMasterTask> CommandTask::CreateOperate(const std::shared_ptr<TaskContext>& context,
-                                                        CommandSet&& set,
-                                                        IndexQualifierMode mode,
-                                                        IMasterApplication& app,
-                                                        const CommandResultCallbackT& callback,
-                                                        const Timestamp& startExpiration,
-                                                        const TaskConfig& config,
-                                                        Logger logger)
-{
-    auto task
-        = std::make_shared<CommandTask>(context, std::move(set), mode, app, callback, startExpiration, config, logger);
+std::shared_ptr<IMasterTask> CommandTask::CreateOperate(
+    const std::shared_ptr<TaskContext>& context,
+    CommandSet&& set,
+    IndexQualifierMode mode,
+    IMasterApplication& app,
+    const CommandResultCallbackT& callback,
+    const TaskConfig& config,
+    const TaskBehavior& taskBehavior,
+    Logger logger
+) {
+    auto task = std::make_shared<CommandTask>(context, std::move(set), mode, app, callback, config, taskBehavior, logger);
     task->LoadOperate();
     return task;
 }
 
-CommandTask::CommandTask(const std::shared_ptr<TaskContext>& context,
-                         CommandSet&& commands,
-                         IndexQualifierMode mode,
-                         IMasterApplication& app,
-                         CommandResultCallbackT callback,
-                         const Timestamp& startExpiration,
-                         const TaskConfig& config,
-                         const Logger& logger)
-    : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(startExpiration), logger, config),
-      statusResult(CommandStatus::UNDEFINED),
-      commandCallback(std::move(callback)),
-      commands(std::move(commands)),
-      mode(mode)
-{
-}
+CommandTask::CommandTask(
+    const std::shared_ptr<TaskContext>& context,
+    CommandSet&& commands,
+    IndexQualifierMode mode,
+    IMasterApplication& app,
+    CommandResultCallbackT callback,
+    const TaskConfig& config,
+    const TaskBehavior& taskBehavior,
+    const Logger& logger
+)
+    : IMasterTask(context, app, taskBehavior, logger, config)
+    , statusResult(CommandStatus::UNDEFINED)
+    , commandCallback(std::move(callback))
+    , commands(std::move(commands))
+    , mode(mode)
+{}
 
 void CommandTask::LoadSelectAndOperate()
 {

--- a/cpp/lib/src/master/CommandTask.h
+++ b/cpp/lib/src/master/CommandTask.h
@@ -43,48 +43,60 @@ class CommandTask : public IMasterTask
 {
 
 public:
-    CommandTask(const std::shared_ptr<TaskContext>& context,
-                CommandSet&& commands,
-                IndexQualifierMode mode,
-                IMasterApplication& app,
-                CommandResultCallbackT callback,
-                const Timestamp& startExpiration,
-                const TaskConfig& config,
-                const Logger& logger);
+    CommandTask(
+        const std::shared_ptr<TaskContext>& context,
+        CommandSet&& commands,
+        IndexQualifierMode mode,
+        IMasterApplication& app,
+        CommandResultCallbackT callback,
+        const TaskConfig& config,
+        const TaskBehavior& taskBehavior,
+        const Logger& logger
+    );
 
-    static std::shared_ptr<IMasterTask> CreateDirectOperate(const std::shared_ptr<TaskContext>& context,
-                                                            CommandSet&& set,
-                                                            IndexQualifierMode mode,
-                                                            IMasterApplication& app,
-                                                            const CommandResultCallbackT& callback,
-                                                            const Timestamp& startExpiration,
-                                                            const TaskConfig& config,
-                                                            Logger logger);
-    static std::shared_ptr<IMasterTask> CreateSelectAndOperate(const std::shared_ptr<TaskContext>& context,
-                                                               CommandSet&& set,
-                                                               IndexQualifierMode mode,
-                                                               IMasterApplication& app,
-                                                               const CommandResultCallbackT& callback,
-                                                               const Timestamp& startExpiration,
-                                                               const TaskConfig& config,
-                                                               Logger logger);
-    static std::shared_ptr<IMasterTask> CreateSelect(const std::shared_ptr<TaskContext>& context,
-                                                     CommandSet&& set,
-                                                     IndexQualifierMode mode,
-                                                     IMasterApplication& app,
-                                                     const CommandResultCallbackT& callback,
-                                                     const Timestamp& startExpiration,
-                                                     const TaskConfig& config,
-                                                     Logger logger);
+    static std::shared_ptr<IMasterTask> CreateDirectOperate(
+        const std::shared_ptr<TaskContext>& context,
+        CommandSet&& set,
+        IndexQualifierMode mode,
+        IMasterApplication& app,
+        const CommandResultCallbackT& callback,
+        const TaskConfig& config,
+        const TaskBehavior& taskBehavior,
+        Logger logger
+    );
 
-    static std::shared_ptr<IMasterTask> CreateOperate(const std::shared_ptr<TaskContext>& context,
-                                                      CommandSet&& set,
-                                                      IndexQualifierMode mode,
-                                                      IMasterApplication& app,
-                                                      const CommandResultCallbackT& callback,
-                                                      const Timestamp& startExpiration,
-                                                      const TaskConfig& config,
-                                                      Logger logger);
+    static std::shared_ptr<IMasterTask> CreateSelectAndOperate(
+        const std::shared_ptr<TaskContext>& context,
+        CommandSet&& set,
+        IndexQualifierMode mode,
+        IMasterApplication& app,
+        const CommandResultCallbackT& callback,
+        const TaskConfig& config,
+        const TaskBehavior& taskBehavior,
+        Logger logger
+    );
+
+    static std::shared_ptr<IMasterTask> CreateSelect(
+        const std::shared_ptr<TaskContext>& context,
+        CommandSet&& set,
+        IndexQualifierMode mode,
+        IMasterApplication& app,
+        const CommandResultCallbackT& callback,
+        const TaskConfig& config,
+        const TaskBehavior& taskBehavior,
+        Logger logger
+    );
+
+    static std::shared_ptr<IMasterTask> CreateOperate(
+        const std::shared_ptr<TaskContext>& context,
+        CommandSet&& set,
+        IndexQualifierMode mode,
+        IMasterApplication& app,
+        const CommandResultCallbackT& callback,
+        const TaskConfig& config,
+        const TaskBehavior& taskBehavior,
+        Logger logger
+    );
 
 
     char const* Name() const final

--- a/cpp/lib/src/master/DeleteFileTask.cpp
+++ b/cpp/lib/src/master/DeleteFileTask.cpp
@@ -14,26 +14,29 @@
 namespace opendnp3
 {
 
-    DeleteFileTask::DeleteFileTask(const std::shared_ptr<TaskContext>& context,
+    DeleteFileTask::DeleteFileTask(
+        const std::shared_ptr<TaskContext>& context,
         IMasterApplication& app,
         const Logger& logger,
-        std::string filename, 
-        FileOperationTaskCallbackT taskCallback)
-        : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(), logger, TaskConfig::Default()),
-        filename(std::move(filename))
+        std::string filename,
+        const TaskBehavior& taskBehavior,
+        FileOperationTaskCallbackT taskCallback
+    )
+        : IMasterTask(context, app, taskBehavior, logger, TaskConfig::Default())
+        , _filename(std::move(filename))
     {
-        callback = taskCallback ? std::move(taskCallback) : [](const FileOperationTaskResult& /**/) {};
+        _callback = taskCallback ? std::move(taskCallback) : [](const FileOperationTaskResult& /**/) {};
     }
 
     void DeleteFileTask::Initialize()
     {
-        fileCommandStatus = Group70Var4();
+        _fileCommandStatus = Group70Var4();
     }
 
     bool DeleteFileTask::BuildRequest(APDURequest& request, uint8_t seq) {
         logger.log(flags::DBG, __FILE__, "Attempting delete file");
         Group70Var3 file;
-        file.filename = filename;
+        file.filename = _filename;
         file.operationMode = FileOpeningMode::DELETING;
         request.SetFunction(FunctionCode::DELETE_FILE);
         request.SetControl(AppControlField::Request(seq));
@@ -47,16 +50,16 @@ namespace opendnp3
             FileOperationHandler handler;
             const auto result = APDUParser::Parse(objects, handler, &logger);
             if (result != ParseResult::OK) {
-                callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
+                _callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
                 return ResponseResult::ERROR_BAD_RESPONSE;
             }
-            fileCommandStatus = handler.GetFileStatusObject();
+            _fileCommandStatus = handler.GetFileStatusObject();
             std::string s;
-            switch (fileCommandStatus.status) {
+            switch (_fileCommandStatus.status) {
             case FileCommandStatus::SUCCESS:
-                s = "Success deleting file - \"" + filename + "\"";
+                s = "Success deleting file - \"" + _filename + "\"";
                 logger.log(flags::DBG, __FILE__, s.c_str());
-                callback(FileOperationTaskResult(TaskCompletion::SUCCESS));
+                _callback(FileOperationTaskResult(TaskCompletion::SUCCESS));
                 return ResponseResult::OK_FINAL;
             case FileCommandStatus::PERMISSION_DENIED:
                 logger.log(flags::DBG, __FILE__, "Permission denied");
@@ -65,18 +68,18 @@ namespace opendnp3
                 logger.log(flags::DBG, __FILE__, "Invalid mode");
                 break;
             case FileCommandStatus::NOT_FOUND:
-                s = "File - \"" + filename + "\" not found";
+                s = "File - \"" + _filename + "\" not found";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::FILE_LOCKED:
-                s = "File - \"" + filename + "\" locked by another user";
+                s = "File - \"" + _filename + "\" locked by another user";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::OPEN_COUNT_EXCEEDED:
                 logger.log(flags::DBG, __FILE__, "Maximum amount of files opened");
                 break;
             case FileCommandStatus::FILE_NOT_OPEN:
-                s = "File - \"" + filename + "\" not opened";
+                s = "File - \"" + _filename + "\" not opened";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::INVALID_BLOCK_SIZE:
@@ -94,7 +97,7 @@ namespace opendnp3
             }
         }
 
-        callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
+        _callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
         return ResponseResult::ERROR_BAD_RESPONSE;
     }
 

--- a/cpp/lib/src/master/DeleteFileTask.h
+++ b/cpp/lib/src/master/DeleteFileTask.h
@@ -14,8 +14,14 @@ namespace opendnp3
     {
 
     public:
-        DeleteFileTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger,
-            std::string filename, FileOperationTaskCallbackT taskCallback);
+        DeleteFileTask(
+            const std::shared_ptr<TaskContext>& context,
+            IMasterApplication& app,
+            const Logger& logger,
+            std::string filename,
+            const TaskBehavior& taskBehavior,
+            FileOperationTaskCallbackT taskCallback
+        );
 
         char const* Name() const final
         {
@@ -56,9 +62,9 @@ namespace opendnp3
         void Initialize() final;
 
     private:
-        std::string filename;
-        Group70Var4 fileCommandStatus;
-        FileOperationTaskCallbackT callback;
+        std::string _filename;
+        Group70Var4 _fileCommandStatus;
+        FileOperationTaskCallbackT _callback;
     };
 
 } // namespace opendnp3

--- a/cpp/lib/src/master/EmptyResponseTask.cpp
+++ b/cpp/lib/src/master/EmptyResponseTask.cpp
@@ -31,10 +31,10 @@ EmptyResponseTask::EmptyResponseTask(const std::shared_ptr<TaskContext>& context
                                      std::string name,
                                      FunctionCode func,
                                      std::function<bool(HeaderWriter&)> format,
-                                     Timestamp startExpiration,
                                      const Logger& logger,
+                                     const TaskBehavior& taskBehavior,
                                      const TaskConfig& config)
-    : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(startExpiration), logger, config),
+    : IMasterTask(context, app, taskBehavior, logger, config),
       name(std::move(name)),
       func(func),
       format(std::move(format))

--- a/cpp/lib/src/master/EmptyResponseTask.h
+++ b/cpp/lib/src/master/EmptyResponseTask.h
@@ -38,8 +38,8 @@ public:
                       std::string name,
                       FunctionCode func,
                       HeaderBuilderT format,
-                      Timestamp startExpiration,
                       const Logger& logger,
+                      const TaskBehavior& taskBehavior,
                       const TaskConfig& config);
 
     bool BuildRequest(APDURequest& request, uint8_t seq) override;

--- a/cpp/lib/src/master/EventScanTask.cpp
+++ b/cpp/lib/src/master/EventScanTask.cpp
@@ -37,7 +37,7 @@ EventScanTask::EventScanTask(const std::shared_ptr<TaskContext>& context,
                              ClassField classes,
                              const Logger& logger)
     : PollTaskBase(
-          context,
+        context,
         application,
         std::move(soeHandler),
         TaskBehavior::ReactsToIINOnly(),

--- a/cpp/lib/src/master/GetFileInfoTask.cpp
+++ b/cpp/lib/src/master/GetFileInfoTask.cpp
@@ -14,26 +14,30 @@
 namespace opendnp3
 {
 
-    GetFileInfoTask::GetFileInfoTask(const std::shared_ptr<TaskContext>& context,
+    GetFileInfoTask::GetFileInfoTask(
+        const std::shared_ptr<TaskContext>& context,
         IMasterApplication& app,
         const Logger& logger,
         std::string sourceFile,
-        GetFilesInfoTaskCallbackT taskCallback)
-        : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(), logger, TaskConfig::Default()),
-          sourceFile(std::move(sourceFile)), callback(std::move(taskCallback))
+        const TaskBehavior& taskBehavior,
+        GetFilesInfoTaskCallbackT taskCallback
+    )
+        : IMasterTask(context, app, taskBehavior, logger, TaskConfig::Default())
+        , _sourceFile(std::move(sourceFile))
+        , _callback(std::move(taskCallback))
     { }
 
     void GetFileInfoTask::Initialize()
     {
-        fileInfo = DNPFileInfo();
-        if (callback == nullptr) {
-            callback = [](const GetFilesInfoTaskResult& /**/) {};
+        _fileInfo = DNPFileInfo();
+        if (_callback == nullptr) {
+            _callback = [](const GetFilesInfoTaskResult& /**/) {};
         }
     }
 
     bool GetFileInfoTask::BuildRequest(APDURequest& request, uint8_t seq) {
         Group70Var7 obj;
-        obj.fileInfo.filename = sourceFile;
+        obj.fileInfo.filename = _sourceFile;
         obj.asData = false; // obj isn't a part of another object
         request.SetFunction(FunctionCode::GET_FILE_INFO);
         request.SetControl(AppControlField::Request(seq));
@@ -52,8 +56,8 @@ namespace opendnp3
             // we can get either var 7 or var 4 as a response
             const Group70Var7 obj = handler.GetFileDescriptorObject();
             if (obj.isInitialized) { // if obj is inialized - response contains var 7
-                fileInfo = obj.fileInfo;
-                callback(GetFilesInfoTaskResult(TaskCompletion::SUCCESS, { fileInfo }));
+                _fileInfo = obj.fileInfo;
+                _callback(GetFilesInfoTaskResult(TaskCompletion::SUCCESS, { _fileInfo }));
                 return ResponseResult::OK_FINAL;
             }
             const auto fileCommandStatus = handler.GetFileStatusObject();
@@ -65,7 +69,7 @@ namespace opendnp3
             switch (fileCommandStatus.status) {
             case FileCommandStatus::SUCCESS: {
                 logger.log(flags::DBG, __FILE__, "Successfully received file info");
-                callback(GetFilesInfoTaskResult(TaskCompletion::SUCCESS, { fileInfo }));
+                _callback(GetFilesInfoTaskResult(TaskCompletion::SUCCESS, { _fileInfo }));
                 return ResponseResult::OK_FINAL;
             }
             case FileCommandStatus::PERMISSION_DENIED:
@@ -75,18 +79,18 @@ namespace opendnp3
                 logger.log(flags::DBG, __FILE__, "Invalid mode");
                 break;
             case FileCommandStatus::NOT_FOUND:
-                s = "File - \"" + sourceFile + "\" not found";
+                s = "File - \"" + _sourceFile + "\" not found";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::FILE_LOCKED:
-                s = "File - \"" + sourceFile + "\" locked by another user";
+                s = "File - \"" + _sourceFile + "\" locked by another user";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::OPEN_COUNT_EXCEEDED:
                 logger.log(flags::DBG, __FILE__, "Maximum amount of files opened");
                 break;
             case FileCommandStatus::FILE_NOT_OPEN:
-                s = "File - \"" + sourceFile + "\" not opened";
+                s = "File - \"" + _sourceFile + "\" not opened";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::INVALID_BLOCK_SIZE:
@@ -94,7 +98,7 @@ namespace opendnp3
                 break;
             case FileCommandStatus::LOST_COM:
                 logger.log(flags::DBG, __FILE__, "Communication lost");
-                callback(GetFilesInfoTaskResult(TaskCompletion::FAILURE_NO_COMMS));
+                _callback(GetFilesInfoTaskResult(TaskCompletion::FAILURE_NO_COMMS));
                 break;
             case FileCommandStatus::FAILED_ABORT:
                 logger.log(flags::DBG, __FILE__, "Abort action failed");

--- a/cpp/lib/src/master/GetFileInfoTask.h
+++ b/cpp/lib/src/master/GetFileInfoTask.h
@@ -12,8 +12,14 @@ namespace opendnp3
     class GetFileInfoTask : public IMasterTask {
 
     public:
-        GetFileInfoTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger,
-            std::string sourceFile, GetFilesInfoTaskCallbackT taskCallback);
+        GetFileInfoTask(
+            const std::shared_ptr<TaskContext>& context,
+            IMasterApplication& app,
+            const Logger& logger,
+            std::string sourceFile,
+            const TaskBehavior& taskBehavior,
+            GetFilesInfoTaskCallbackT taskCallback
+        );
 
         char const* Name() const final
         {
@@ -54,9 +60,9 @@ namespace opendnp3
         void Initialize() final;
 
     private:
-        std::string sourceFile;
-        DNPFileInfo fileInfo{};
-        GetFilesInfoTaskCallbackT callback;
+        std::string _sourceFile;
+        DNPFileInfo _fileInfo{};
+        GetFilesInfoTaskCallbackT _callback;
     };
 
 } // namespace opendnp3

--- a/cpp/lib/src/master/GetFilesInDirectoryTask.cpp
+++ b/cpp/lib/src/master/GetFilesInDirectoryTask.cpp
@@ -14,33 +14,38 @@
 namespace opendnp3
 {
 
-    GetFilesInDirectoryTask::GetFilesInDirectoryTask(const std::shared_ptr<TaskContext>& context,
+    GetFilesInDirectoryTask::GetFilesInDirectoryTask(
+        const std::shared_ptr<TaskContext>& context,
         IMasterApplication& app,
         const Logger& logger,
         std::string sourceDirectory,
+        const TaskBehavior& taskBehavior,
         GetFilesInfoTaskCallbackT taskCallback,
-        uint16_t rxSize)
-        : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(), logger, TaskConfig::Default()),
-          sourceDirectory(std::move(sourceDirectory)), callback(std::move(taskCallback)), _rxSize(rxSize)
+        uint16_t rxSize
+    )
+        : IMasterTask(context, app, taskBehavior, logger, TaskConfig::Default())
+        , _sourceDirectory(std::move(sourceDirectory))
+        , _callback(std::move(taskCallback))
+        , _rxSize(rxSize)
     { }
 
     void GetFilesInDirectoryTask::Initialize()
     {
-        currentTaskState = OPENING;
-        fileCommandStatus = Group70Var4();
-        fileTransportObject = Group70Var5();
-        filesInfo.clear();
-        if (callback == nullptr) {
-            callback = [](const GetFilesInfoTaskResult& /**/) {};
+        _currentTaskState = OPENING;
+        _fileCommandStatus = Group70Var4();
+        _fileTransportObject = Group70Var5();
+        _filesInfo.clear();
+        if (_callback == nullptr) {
+            _callback = [](const GetFilesInfoTaskResult& /**/) {};
         }
     }
 
     bool GetFilesInDirectoryTask::BuildRequest(APDURequest& request, uint8_t seq) {
-        switch (currentTaskState) {
+        switch (_currentTaskState) {
             case OPENING: {
                 logger.log(flags::DBG, __FILE__, "Attempting opening directory");
                 Group70Var3 file;
-                file.filename = sourceDirectory;
+                file.filename = _sourceDirectory;
                 file.blockSize = _rxSize;
                 request.SetFunction(FunctionCode::OPEN_FILE);
                 request.SetControl(AppControlField::Request(seq));
@@ -48,17 +53,17 @@ namespace opendnp3
                 return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var3>(QualifierCode::FREE_FORMAT, file);
             }
             case READING_DIRECTORY: {
-                fileTransportObject.fileId = fileCommandStatus.fileId;
+                _fileTransportObject.fileId = _fileCommandStatus.fileId;
                 request.SetFunction(FunctionCode::READ);
                 request.SetControl(AppControlField::Request(seq));
                 auto writer = request.GetWriter();
-                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var5>(QualifierCode::FREE_FORMAT, fileTransportObject);
+                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var5>(QualifierCode::FREE_FORMAT, _fileTransportObject);
             }
             case CLOSING: {
                 request.SetFunction(FunctionCode::CLOSE_FILE);
                 request.SetControl(AppControlField::Request(seq));
                 auto writer = request.GetWriter();
-                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var4>(QualifierCode::FREE_FORMAT, fileCommandStatus);
+                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var4>(QualifierCode::FREE_FORMAT, _fileCommandStatus);
             }
         }
 
@@ -67,7 +72,7 @@ namespace opendnp3
 
     IMasterTask::ResponseResult GetFilesInDirectoryTask::ProcessResponse(const APDUResponseHeader& response,
                                                               const ser4cpp::rseq_t& objects) {
-        switch (currentTaskState) {
+        switch (_currentTaskState) {
             case OPENING:
             case CLOSING:
                 return OnResponseStatusObject(response, objects);
@@ -86,29 +91,29 @@ namespace opendnp3
             if (result != ParseResult::OK) {
                 return ResponseResult::ERROR_BAD_RESPONSE;
             }
-            fileCommandStatus = handler.GetFileStatusObject();
+            _fileCommandStatus = handler.GetFileStatusObject();
             std::string s;
-            switch (fileCommandStatus.status) {
+            switch (_fileCommandStatus.status) {
                 case FileCommandStatus::SUCCESS: {
-                    switch (currentTaskState) {
+                    switch (_currentTaskState) {
                         case OPENING:
-                            s = "Reading files in directory - \"" + sourceDirectory + "\"";
+                            s = "Reading files in directory - \"" + _sourceDirectory + "\"";
                             logger.log(flags::DBG, __FILE__, s.c_str());
-                            currentTaskState = READING_DIRECTORY;
+                            _currentTaskState = READING_DIRECTORY;
                             return ResponseResult::OK_REPEAT;
                         case READING_DIRECTORY:
                             logger.log(flags::DBG, __FILE__, "Successfully received file names");
                             logger.log(flags::DBG, __FILE__, "Reading each file...");
-                            currentTaskState = CLOSING;
+                            _currentTaskState = CLOSING;
                             return ResponseResult::OK_REPEAT;
                         case CLOSING:
-                            s = "Successfully closed directory - \"" + sourceDirectory + "\"";
+                            s = "Successfully closed directory - \"" + _sourceDirectory + "\"";
                             logger.log(flags::DBG, __FILE__, s.c_str());
-                            if (errorWhileReading) {
-                                callback(GetFilesInfoTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
+                            if (_errorWhileReading) {
+                                _callback(GetFilesInfoTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
                                 return ResponseResult::ERROR_BAD_RESPONSE;
                             }
-                            callback(GetFilesInfoTaskResult(TaskCompletion::SUCCESS, filesInfo));
+                            _callback(GetFilesInfoTaskResult(TaskCompletion::SUCCESS, _filesInfo));
                             return ResponseResult::OK_FINAL;
                         default: 
                             return ResponseResult::ERROR_BAD_RESPONSE;
@@ -121,18 +126,18 @@ namespace opendnp3
                     logger.log(flags::DBG, __FILE__, "Invalid mode");
                     break;
                 case FileCommandStatus::NOT_FOUND:
-                    s = "Directory - \"" + sourceDirectory + "\" not found";
+                    s = "Directory - \"" + _sourceDirectory + "\" not found";
                     logger.log(flags::DBG, __FILE__, s.c_str());
                     break;
                 case FileCommandStatus::FILE_LOCKED:
-                    s = "Directory - \"" + sourceDirectory + "\" locked by another user";
+                    s = "Directory - \"" + _sourceDirectory + "\" locked by another user";
                     logger.log(flags::DBG, __FILE__, s.c_str());
                     break;
                 case FileCommandStatus::OPEN_COUNT_EXCEEDED:
                     logger.log(flags::DBG, __FILE__, "Maximum amount of files opened");
                     break;
                 case FileCommandStatus::FILE_NOT_OPEN:
-                    s = "Directory - \"" + sourceDirectory + "\" not opened";
+                    s = "Directory - \"" + _sourceDirectory + "\" not opened";
                     logger.log(flags::DBG, __FILE__, s.c_str());
                     break;
                 case FileCommandStatus::INVALID_BLOCK_SIZE:
@@ -140,7 +145,7 @@ namespace opendnp3
                     break;
                 case FileCommandStatus::LOST_COM:
                     logger.log(flags::DBG, __FILE__, "Communication lost");
-                    callback(GetFilesInfoTaskResult(TaskCompletion::FAILURE_NO_COMMS));
+                    _callback(GetFilesInfoTaskResult(TaskCompletion::FAILURE_NO_COMMS));
                     break;
                 case FileCommandStatus::FAILED_ABORT:
                     logger.log(flags::DBG, __FILE__, "Abort action failed");
@@ -151,7 +156,7 @@ namespace opendnp3
             }
         }
 
-        callback(GetFilesInfoTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
+        _callback(GetFilesInfoTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
         return ResponseResult::ERROR_BAD_RESPONSE;
     }
 
@@ -161,20 +166,20 @@ namespace opendnp3
             FileOperationHandler handler;
             const auto result = APDUParser::Parse(objects, handler, &logger);
             if (result != ParseResult::OK) {
-                errorWhileReading = true;
-                currentTaskState = CLOSING;
+                _errorWhileReading = true;
+                _currentTaskState = CLOSING;
                 return ResponseResult::OK_REPEAT;
             }
 
-            fileTransportObject = handler.GetFileTransferObject();
-            while (fileTransportObject.data.length() != 0)
+            _fileTransportObject = handler.GetFileTransferObject();
+            while (_fileTransportObject.data.length() != 0)
             {
                 Group70Var7 info;
-                Group70Var7::Read(fileTransportObject.data, info);
-                filesInfo.push_back(info.fileInfo);
+                Group70Var7::Read(_fileTransportObject.data, info);
+                _filesInfo.push_back(info.fileInfo);
             }
 
-            currentTaskState = CLOSING;
+            _currentTaskState = CLOSING;
             return ResponseResult::OK_REPEAT;
         }
         return ResponseResult::ERROR_BAD_RESPONSE;

--- a/cpp/lib/src/master/GetFilesInDirectoryTask.h
+++ b/cpp/lib/src/master/GetFilesInDirectoryTask.h
@@ -15,8 +15,15 @@ namespace opendnp3
     class GetFilesInDirectoryTask : public IMasterTask {
 
     public:
-        GetFilesInDirectoryTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger,
-            std::string sourceDirectory, GetFilesInfoTaskCallbackT taskCallback, uint16_t rxSize);
+        GetFilesInDirectoryTask(
+            const std::shared_ptr<TaskContext>& context,
+            IMasterApplication& app,
+            const Logger& logger,
+            std::string sourceDirectory,
+            const TaskBehavior& taskBehavior,
+            GetFilesInfoTaskCallbackT taskCallback,
+            uint16_t rxSize
+        );
 
         char const* Name() const final
         {
@@ -60,14 +67,14 @@ namespace opendnp3
         void Initialize() final;
 
     private:
-        FileOperationTaskState currentTaskState{ OPENING };
-        std::string sourceDirectory;
-        Group70Var4 fileCommandStatus;
-        Group70Var5 fileTransportObject;
-        std::deque<DNPFileInfo> filesInfo;
-        GetFilesInfoTaskCallbackT callback;
+        FileOperationTaskState _currentTaskState{ OPENING };
+        std::string _sourceDirectory;
+        Group70Var4 _fileCommandStatus;
+        Group70Var5 _fileTransportObject;
+        std::deque<DNPFileInfo> _filesInfo;
+        GetFilesInfoTaskCallbackT _callback;
         uint16_t _rxSize;
-        bool errorWhileReading = false;
+        bool _errorWhileReading{ false };
     };
 
 } // namespace opendnp3

--- a/cpp/lib/src/master/IMasterTask.cpp
+++ b/cpp/lib/src/master/IMasterTask.cpp
@@ -61,18 +61,17 @@ IMasterTask::ResponseResult IMasterTask::OnResponse(const APDUResponseHeader& re
                                                     const ser4cpp::rseq_t& objects,
                                                     Timestamp now)
 {
-    auto result = this->ProcessResponse(response, objects);
-
+    const auto result = this->ProcessResponse(response, objects);
     switch (result)
     {
-    case (ResponseResult::ERROR_BAD_RESPONSE):
-        this->CompleteTask(TaskCompletion::FAILURE_BAD_RESPONSE, now);
-        break;
-    case (ResponseResult::OK_FINAL):
-        this->CompleteTask(TaskCompletion::SUCCESS, now);
-        break;
-    default:
-        break;
+        case ResponseResult::ERROR_BAD_RESPONSE:
+            this->CompleteTask(TaskCompletion::FAILURE_BAD_RESPONSE, now);
+            break;
+        case ResponseResult::OK_FINAL:
+            this->CompleteTask(TaskCompletion::SUCCESS, now);
+            break;
+        default:
+            break;
     }
 
     return result;
@@ -82,69 +81,68 @@ void IMasterTask::CompleteTask(TaskCompletion result, Timestamp now)
 {
     switch (result)
     {
+        // retry immediately when the comms come back online
+        case TaskCompletion::FAILURE_NO_COMMS:
+            this->behavior.Reset();
+            break;
 
-    // retry immediately when the comms come back online
-    case (TaskCompletion::FAILURE_NO_COMMS):
-        this->behavior.Reset();
-        break;
-
-    // back-off exponentially using the task retry
-    case (TaskCompletion::FAILURE_RESPONSE_TIMEOUT):
-    {
-        const auto timeoutStats = this->behavior.OnResponseTimeout(now);
-        if (this->BlocksLowerPriority()) {
-            this->context->AddBlock(*this);
-        }
-        _retriesFinished = true;
-        if (timeoutStats.IsFixedRetriesCount) {
-            if (!timeoutStats.IsFinished) {
-                _retriesFinished = false;
+        // back-off exponentially using the task retry
+        case TaskCompletion::FAILURE_RESPONSE_TIMEOUT:
+        {
+            const auto timeoutStats = this->behavior.OnResponseTimeout(now);
+            if (this->BlocksLowerPriority()) {
+                this->context->AddBlock(*this);
+            }
+            _retriesFinished = true;
+            if (timeoutStats.IsFixedRetriesCount) {
+                if (!timeoutStats.IsFinished) {
+                    _retriesFinished = false;
+                    FORMAT_LOG_BLOCK(
+                        logger,
+                        flags::WARN,
+                        "Task '%s' completed with timeout, current retry is '%llu' out of '%llu'",
+                        Name(),
+                        timeoutStats.CurrentRetryNumber,
+                        timeoutStats.MaxRetryNumber
+                    )
+                    return;
+                }
                 FORMAT_LOG_BLOCK(
                     logger,
                     flags::WARN,
-                    "Task '%s' completed with timeout, current retry is '%llu' out of '%llu'",
+                    "Task '%s' completed with timeout, out of retries (max retries - '%llu')",
                     Name(),
-                    timeoutStats.CurrentRetryNumber,
                     timeoutStats.MaxRetryNumber
                 )
-                return;
             }
-            FORMAT_LOG_BLOCK(
-                logger,
-                flags::WARN,
-                "Task '%s' completed with timeout, out of retries (max retries - '%llu')",
-                Name(),
-                timeoutStats.MaxRetryNumber
-            )
+            else {
+                FORMAT_LOG_BLOCK(
+                    logger,
+                    flags::WARN,
+                    "Task '%s' completed with timeout and the number of retries set to 'infinite'. Each retry is treated as its own task",
+                    Name()
+                )
+            }
+            break;
         }
-        else {
-            FORMAT_LOG_BLOCK(
-                logger,
-                flags::WARN,
-                "Task '%s' completed with timeout and the number of retries set to 'infinite'. Each retry is treated as its own task",
-                Name()
-            )
-        }
-        break;
-    }
 
-    case (TaskCompletion::SUCCESS):
-        this->behavior.OnSuccess(now);
-        this->context->RemoveBlock(*this);
-        break;
+        case TaskCompletion::SUCCESS:
+            this->behavior.OnSuccess(now);
+            this->context->RemoveBlock(*this);
+            break;
 
-    /**
-    FAILURE_BAD_RESPONSE
-    FAILURE_START_TIMEOUT
-    FAILURE_MESSAGE_FORMAT_ERROR
-    */
-    default:
-    {
-        this->behavior.Disable();
-        if (this->BlocksLowerPriority()) {
-            this->context->AddBlock(*this);
+        /**
+        FAILURE_BAD_RESPONSE
+        FAILURE_START_TIMEOUT
+        FAILURE_MESSAGE_FORMAT_ERROR
+        */
+        default:
+        {
+            this->behavior.Disable();
+            if (this->BlocksLowerPriority()) {
+                this->context->AddBlock(*this);
+            }
         }
-    }
     }
 
     if (config.pCallback)
@@ -191,7 +189,7 @@ bool IMasterTask::OnStart(Timestamp now)
         config.pCallback->OnStart(Name());
     }
 
-    bool isTaskStarted = this->application->OnTaskStart(this->GetTaskType(), config.taskId);
+    const bool isTaskStarted = this->application->OnTaskStart(this->GetTaskType(), config.taskId);
     if (isTaskStarted)
     {
         this->Initialize();
@@ -248,8 +246,7 @@ bool IMasterTask::ValidateInternalIndications(const APDUResponseHeader& header)
 {
     if (header.IIN.HasRequestError())
     {
-        FORMAT_LOG_BLOCK(logger, flags::WARN, "Task was explicitly rejected via response with error IIN bit(s): %s",
-                         this->Name())
+        FORMAT_LOG_BLOCK(logger, flags::WARN, "Task was explicitly rejected via response with error IIN bit(s): %s", this->Name())
         return false;
     }
 

--- a/cpp/lib/src/master/LANTimeSyncTask.cpp
+++ b/cpp/lib/src/master/LANTimeSyncTask.cpp
@@ -34,13 +34,13 @@ LANTimeSyncTask::LANTimeSyncTask(const std::shared_ptr<TaskContext>& context,
 {
 }
 
-LANTimeSyncTask::LANTimeSyncTask(const std::shared_ptr<TaskContext>& context,
-                                 IMasterApplication& app,
-                                 const Logger& logger,
-                                 TimeDuration period,
-                                 TimeDuration mixRetryTimeout,
-                                 TimeDuration maxRetryTimeout)
-    : IMasterTask(context, app, TaskBehavior::ImmediatePeriodic(period, mixRetryTimeout, maxRetryTimeout), logger, TaskConfig::Default())
+LANTimeSyncTask::LANTimeSyncTask(
+    const std::shared_ptr<TaskContext>& context,
+    IMasterApplication& app,
+    const Logger& logger,
+    const TaskBehavior& taskBehavior
+)
+    : IMasterTask(context, app, taskBehavior, logger, TaskConfig::Default())
 { }
 
 void LANTimeSyncTask::Initialize()

--- a/cpp/lib/src/master/LANTimeSyncTask.h
+++ b/cpp/lib/src/master/LANTimeSyncTask.h
@@ -38,8 +38,12 @@ class LANTimeSyncTask : public IMasterTask
 
 public:
     LANTimeSyncTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger);
-    LANTimeSyncTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger,
-                    TimeDuration period, TimeDuration mixRetryTimeout, TimeDuration maxRetryTimeout);
+    LANTimeSyncTask(
+        const std::shared_ptr<TaskContext>& context,
+        IMasterApplication& app,
+        const Logger& logger,
+        const TaskBehavior& taskBehavior
+    );
 
     char const* Name() const final
     {

--- a/cpp/lib/src/master/MasterContext.cpp
+++ b/cpp/lib/src/master/MasterContext.cpp
@@ -99,11 +99,10 @@ std::shared_ptr<MContext> MContext::Create(
     std::weak_ptr<MContext> weakPtr = ptr;
     ptr->iohandlersManager->SetChannelStateChangedCallback([weakPtr](const bool channelDown) {
         const auto shared = weakPtr.lock();
-        if (!shared)
+        if (shared)
         {
-            return;
+            shared->application->OnMasterStatusChanged(channelDown ? MasterStatus::Error : MasterStatus::Working);
         }
-        shared->application->OnStateChange(channelDown ? LinkStatus::UNRESET : LinkStatus::RESET, LinkStateChangeSource::Unconditional);
     });
     return ptr;
 }
@@ -150,19 +149,19 @@ bool MContext::OnReceive(const Message& message)
     std::lock_guard<std::mutex> lock{ _mtx };
     if (!this->isOnline)
     {
-        SIMPLE_LOG_BLOCK(this->logger, flags::ERR, "Ignorning rx data while offline");
+        SIMPLE_LOG_BLOCK(this->logger, flags::ERR, "Ignorning rx data while offline")
         return false;
     }
 
     if (message.addresses.destination != this->addresses.source)
     {
-        FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Unknown destination address: %u", message.addresses.destination);
+        FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Unknown destination address: %u", message.addresses.destination)
         return false;
     }
 
     if (message.addresses.source != this->addresses.destination)
     {
-        FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Unexpected message source: %u", message.addresses.source);
+        FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Unexpected message source: %u", message.addresses.source)
         return false;
     }
 
@@ -223,36 +222,88 @@ void MContext::DirectOperate(CommandSet&& commands, const CommandResultCallbackT
 {
     std::lock_guard<std::mutex> lock{ _mtx };
     const auto timeout = Timestamp(this->executor->get_time()) + params.taskStartTimeout;
-    this->ScheduleAdhocTask(CommandTask::CreateDirectOperate(this->tasks.context, std::move(commands),
-                                                             this->params.controlQualifierMode, *application, callback,
-                                                             timeout, config, logger));
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        timeout,
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    this->ScheduleAdhocTask(CommandTask::CreateDirectOperate(
+        this->tasks.context,
+        std::move(commands),
+        this->params.controlQualifierMode,
+        *application,
+        callback,
+        config,
+        behavior,
+        logger
+    ));
 }
 
 void MContext::SelectAndOperate(CommandSet&& commands, const CommandResultCallbackT& callback, const TaskConfig& config)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
     const auto timeout = Timestamp(this->executor->get_time()) + params.taskStartTimeout;
-    this->ScheduleAdhocTask(CommandTask::CreateSelectAndOperate(this->tasks.context, std::move(commands),
-                                                                this->params.controlQualifierMode, *application,
-                                                                callback, timeout, config, logger));
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        timeout,
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    this->ScheduleAdhocTask(CommandTask::CreateSelectAndOperate(
+        this->tasks.context,
+        std::move(commands),
+        this->params.controlQualifierMode,
+        *application,
+        callback,
+        config,
+        behavior,
+        logger
+    ));
 }
 
 void MContext::Select(CommandSet&& commands, const CommandResultCallbackT& callback, const TaskConfig& config)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
     const auto timeout = Timestamp(this->executor->get_time()) + params.taskStartTimeout;
-    this->ScheduleAdhocTask(CommandTask::CreateSelect(this->tasks.context, std::move(commands),
-                                                      this->params.controlQualifierMode, *application, callback,
-                                                      timeout, config, logger));
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        timeout,
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    this->ScheduleAdhocTask(CommandTask::CreateSelect(
+        this->tasks.context,
+        std::move(commands),
+        this->params.controlQualifierMode,
+        *application,
+        callback,
+        config,
+        behavior,
+        logger
+    ));
 }
 
 void MContext::Operate(CommandSet&& commands, const CommandResultCallbackT& callback, const TaskConfig& config)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
     const auto timeout = Timestamp(this->executor->get_time()) + params.taskStartTimeout;
-    this->ScheduleAdhocTask(CommandTask::CreateOperate(this->tasks.context, std::move(commands),
-                                                      this->params.controlQualifierMode, *application, callback,
-                                                      timeout, config, logger));
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        timeout,
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    this->ScheduleAdhocTask(CommandTask::CreateOperate(
+        this->tasks.context,
+        std::move(commands),
+        this->params.controlQualifierMode,
+        *application,
+        callback,
+        config,
+        behavior,
+        logger
+    ));
 }
 
 void MContext::ProcessAPDU(const APDUResponseHeader& header, const ser4cpp::rseq_t& objects)
@@ -267,7 +318,7 @@ void MContext::ProcessAPDU(const APDUResponseHeader& header, const ser4cpp::rseq
         break;
     default:
         FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Ignoring unsupported function code: %s",
-                         FunctionCodeSpec::to_human_string(header.function));
+                         FunctionCodeSpec::to_human_string(header.function))
         break;
     }
 }
@@ -307,7 +358,7 @@ void MContext::ProcessUnsolicitedResponse(const APDUResponseHeader& header, cons
 {
     if (!header.control.UNS)
     {
-        SIMPLE_LOG_BLOCK(logger, flags::WARN, "Ignoring unsolicited response without UNS bit set");
+        SIMPLE_LOG_BLOCK(logger, flags::WARN, "Ignoring unsolicited response without UNS bit set")
         return;
     }
 
@@ -371,20 +422,48 @@ bool MContext::DemandTimeSyncronization()
     return result;
 }
 
-bool MContext::ReadFile(const std::string& sourceFile, FileOperationTaskCallbackT callback)
+bool MContext::ReadFile(const std::string& sourceFile, const FileOperationTaskCallbackT& callback)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
-    const auto task = std::make_shared<ReadFileTask>(this->tasks.context, *this->application, this->logger, sourceFile,
-                                                     callback, FileTransferMaxRxBlockSize);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        Timestamp::Max(),
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<ReadFileTask>(
+        this->tasks.context,
+        *this->application,
+        this->logger,
+        sourceFile,
+        behavior,
+        callback,
+        FileTransferMaxRxBlockSize
+    );
     this->ScheduleAdhocTask(task);
     return true;
 }
 
-bool MContext::WriteFile(std::shared_ptr<std::ifstream> source, const std::string& destFilename, FileOperationTaskCallbackT callback)
+bool MContext::WriteFile(const std::shared_ptr<std::ifstream>& source, const std::string& destFilename,
+                         const FileOperationTaskCallbackT& callback)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
-    const auto task = std::make_shared<WriteFileTask>(this->tasks.context, *this->application, this->logger,
-                                                      source, destFilename, FileTransferMaxTxBlockSize, callback);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        Timestamp::Max(),
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<WriteFileTask>(
+        this->tasks.context,
+        *this->application,
+        this->logger,
+        source,
+        destFilename,
+        FileTransferMaxTxBlockSize,
+        behavior,
+        callback
+    );
     this->ScheduleAdhocTask(task);
     return true;
 }
@@ -392,22 +471,54 @@ bool MContext::WriteFile(std::shared_ptr<std::ifstream> source, const std::strin
 void MContext::GetFilesInDirectory(const std::string& sourceDirectory, const GetFilesInfoTaskCallbackT& callback)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
-    const auto task = std::make_shared<GetFilesInDirectoryTask>(this->tasks.context, *this->application, this->logger, sourceDirectory,
-                                                                callback, FileTransferMaxRxBlockSize);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        Timestamp::Max(),
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<GetFilesInDirectoryTask>(
+        this->tasks.context,
+        *this->application,
+        this->logger,
+        sourceDirectory,
+        behavior,
+        callback,
+        FileTransferMaxRxBlockSize
+    );
     return this->ScheduleAdhocTask(task);
 }
 
 void MContext::GetFileInfo(const std::string& sourceFile, const GetFilesInfoTaskCallbackT& callback)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
-    const auto task = std::make_shared<GetFileInfoTask>(this->tasks.context, *this->application, this->logger, sourceFile, callback);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        Timestamp::Max(),
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<GetFileInfoTask>(
+        this->tasks.context,
+        *this->application,
+        this->logger,
+        sourceFile,
+        behavior,
+        callback
+    );
     return this->ScheduleAdhocTask(task);
 }
 
-void MContext::DeleteFileFunction(const std::string& filename, FileOperationTaskCallbackT callback)
+void MContext::DeleteFileFunction(const std::string& filename, const FileOperationTaskCallbackT& callback)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
-    const auto task = std::make_shared<DeleteFileTask>(this->tasks.context, *this->application, this->logger, filename, callback);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        Timestamp::Max(),
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<DeleteFileTask>(this->tasks.context, *this->application, this->logger, filename, behavior, callback);
     return this->ScheduleAdhocTask(task);
 }
 
@@ -431,8 +542,8 @@ void MContext::StartResponseTimer()
 
 std::shared_ptr<IMasterTask> MContext::AddScan(TimeDuration period,
                                                const HeaderBuilderT& builder,
-                                               std::shared_ptr<ISOEHandler> soe_handler,
-                                               TaskConfig config)
+                                               const std::shared_ptr<ISOEHandler>& soe_handler,
+                                               const TaskConfig& config)
 {
     auto task = std::make_shared<UserPollTask>(
         this->tasks.context, builder,
@@ -474,13 +585,26 @@ std::shared_ptr<IMasterTask> MContext::AddRangeScan(GroupVariationID gvId,
     return this->AddScan(period, build, soe_handler, config);
 }
 
-void MContext::Scan(const HeaderBuilderT& builder, std::shared_ptr<ISOEHandler> soe_handler, TaskConfig config)
+void MContext::Scan(const HeaderBuilderT& builder, const std::shared_ptr<ISOEHandler>& soe_handler, const TaskConfig&
+                    config)
 {
     const auto timeout = Timestamp(this->executor->get_time()) + params.taskStartTimeout;
-
-    auto task
-        = std::make_shared<UserPollTask>(this->tasks.context, builder, TaskBehavior::SingleExecutionNoRetry(timeout),
-                                         false, *application, soe_handler, logger, config);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        timeout,
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<UserPollTask>(
+        this->tasks.context,
+        builder,
+        behavior,
+        false,
+        *application,
+        soe_handler,
+        logger,
+        config
+    );
 
     this->ScheduleAdhocTask(task);
 }
@@ -507,7 +631,7 @@ void MContext::ScanRange(
     this->Scan(configure, soe_handler, config);
 }
 
-void MContext::Write(const TimeAndInterval& value, uint16_t index, TaskConfig config)
+void MContext::Write(const TimeAndInterval& value, uint16_t index, const TaskConfig& config)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
     auto builder = [value, index](HeaderWriter& writer) -> bool {
@@ -516,29 +640,71 @@ void MContext::Write(const TimeAndInterval& value, uint16_t index, TaskConfig co
     };
 
     const auto timeout = Timestamp(this->executor->get_time()) + params.taskStartTimeout;
-    auto task = std::make_shared<EmptyResponseTask>(this->tasks.context, *this->application, "WRITE TimeAndInterval",
-                                                    FunctionCode::WRITE, builder, timeout, this->logger, config);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        timeout,
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<EmptyResponseTask>(
+        this->tasks.context,
+        *this->application,
+        "WRITE TimeAndInterval",
+        FunctionCode::WRITE,
+        builder,
+        this->logger,
+        behavior,
+        config
+    );
     this->ScheduleAdhocTask(task);
 }
 
-void MContext::Restart(RestartType op, const RestartOperationCallbackT& callback, TaskConfig config)
+void MContext::Restart(RestartType op, const RestartOperationCallbackT& callback, const TaskConfig& config)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
     const auto timeout = Timestamp(this->executor->get_time()) + params.taskStartTimeout;
-    auto task = std::make_shared<RestartOperationTask>(this->tasks.context, *this->application, timeout, op, callback,
-                                                       this->logger, config);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        timeout,
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<RestartOperationTask>(
+        this->tasks.context,
+        *this->application,
+        timeout,
+        op,
+        callback,
+        this->logger,
+        config,
+        behavior
+    );
     this->ScheduleAdhocTask(task);
 }
 
 void MContext::PerformFunction(const std::string& name,
                                FunctionCode func,
                                const HeaderBuilderT& builder,
-                               TaskConfig config)
+                               const TaskConfig& config)
 {
     std::lock_guard<std::mutex> lock{ _mtx };
     const auto timeout = Timestamp(this->executor->get_time()) + params.taskStartTimeout;
-    auto task = std::make_shared<EmptyResponseTask>(this->tasks.context, *this->application, name, func, builder,
-                                                    timeout, this->logger, config);
+    const auto behavior = TaskBehavior::SingleExecutionWithRetry(
+        timeout,
+        this->params.taskRetryPeriod,
+        this->params.maxTaskRetryPeriod,
+        this->params.retryCount
+    );
+    const auto task = std::make_shared<EmptyResponseTask>(
+        this->tasks.context,
+        *this->application,
+        name,
+        func,
+        builder,
+        this->logger,
+        behavior,
+        config
+    );
     this->ScheduleAdhocTask(task);
 }
 
@@ -642,37 +808,31 @@ MContext::TaskState MContext::ResumeActiveTask()
 
 MContext::TaskState MContext::OnTransmitComplete()
 {
-    switch (tstate)
+    if (tstate == TaskState::TASK_READY)
     {
-    case (TaskState::TASK_READY):
         return this->ResumeActiveTask();
-    default:
-        return tstate;
     }
+    return tstate;
 }
 
 MContext::TaskState MContext::OnResponseEvent(const APDUResponseHeader& header, const ser4cpp::rseq_t& objects)
 {
-    switch (tstate)
+    if (tstate == TaskState::WAIT_FOR_RESPONSE)
     {
-    case (TaskState::WAIT_FOR_RESPONSE):
         return OnResponse_WaitForResponse(header, objects);
-    default:
-        FORMAT_LOG_BLOCK(logger, flags::WARN, "Not expecting a response, sequence: %u", header.control.SEQ);
-        return tstate;
     }
+    FORMAT_LOG_BLOCK(logger, flags::WARN, "Not expecting a response, sequence: %u", header.control.SEQ)
+    return tstate;
 }
 
 MContext::TaskState MContext::OnResponseTimeoutEvent()
 {
-    switch (tstate)
+    if (tstate == TaskState::WAIT_FOR_RESPONSE)
     {
-    case (TaskState::WAIT_FOR_RESPONSE):
         return OnResponseTimeout_WaitForResponse();
-    default:
-        SIMPLE_LOG_BLOCK(logger, flags::ERR, "Unexpected response timeout");
-        return tstate;
     }
+    SIMPLE_LOG_BLOCK(logger, flags::ERR, "Unexpected response timeout")
+    return tstate;
 }
 
 //// --- State actions ----
@@ -692,7 +852,7 @@ MContext::TaskState MContext::OnResponse_WaitForResponse(const APDUResponseHeade
 {
     if (header.control.SEQ != this->solSeq)
     {
-        FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Response with bad sequence: %u", header.control.SEQ);
+        FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Response with bad sequence: %u", header.control.SEQ)
         return TaskState::WAIT_FOR_RESPONSE;
     }
 
@@ -735,7 +895,7 @@ MContext::TaskState MContext::OnResponse_WaitForResponse(const APDUResponseHeade
 
 MContext::TaskState MContext::OnResponseTimeout_WaitForResponse()
 {
-    FORMAT_LOG_BLOCK(logger, flags::WARN, "Timeout waiting for response, task - %s", this->activeTask->Name());
+    FORMAT_LOG_BLOCK(logger, flags::WARN, "Timeout waiting for response, task - %s", this->activeTask->Name())
 
     const auto now = Timestamp(this->executor->get_time());
     this->activeTask->OnResponseTimeout(now);

--- a/cpp/lib/src/master/MasterContext.h
+++ b/cpp/lib/src/master/MasterContext.h
@@ -136,8 +136,8 @@ public:
 
     std::shared_ptr<IMasterTask> AddScan(TimeDuration period,
                                          const HeaderBuilderT& builder,
-                                         std::shared_ptr<ISOEHandler> soe_handler,
-                                         TaskConfig config = TaskConfig::Default());
+                                         const std::shared_ptr<ISOEHandler>& soe_handler,
+                                         const TaskConfig& config = TaskConfig::Default());
 
     std::shared_ptr<IMasterTask> AddAllObjectsScan(GroupVariationID gvId,
                                                    TimeDuration period,
@@ -159,8 +159,8 @@ public:
     // ---- Single shot immediate scans ----
 
     void Scan(const HeaderBuilderT& builder,
-              std::shared_ptr<ISOEHandler> soe_handler,
-              TaskConfig config = TaskConfig::Default());
+              const std::shared_ptr<ISOEHandler>& soe_handler,
+              const TaskConfig& config = TaskConfig::Default());
 
     void ScanAllObjects(GroupVariationID gvId,
                         std::shared_ptr<ISOEHandler> soe_handler,
@@ -178,24 +178,25 @@ public:
 
     /// ---- Write tasks -----
 
-    void Write(const TimeAndInterval& value, uint16_t index, TaskConfig config = TaskConfig::Default());
+    void Write(const TimeAndInterval& value, uint16_t index, const TaskConfig& config = TaskConfig::Default());
 
-    void Restart(RestartType op, const RestartOperationCallbackT& callback, TaskConfig config = TaskConfig::Default());
+    void Restart(RestartType op, const RestartOperationCallbackT& callback, const TaskConfig& config = TaskConfig::Default());
 
     void PerformFunction(const std::string& name,
                          FunctionCode func,
                          const HeaderBuilderT& builder,
-                         TaskConfig config = TaskConfig::Default());
+                         const TaskConfig& config = TaskConfig::Default());
 
     /// public state manipulation actions
 
     bool DemandTimeSyncronization();
 
-    bool ReadFile(const std::string& sourceFile, FileOperationTaskCallbackT callback);
-    bool WriteFile(std::shared_ptr<std::ifstream> source, const std::string& destFilename, FileOperationTaskCallbackT callback);
+    bool ReadFile(const std::string& sourceFile, const FileOperationTaskCallbackT& callback);
+    bool WriteFile(const std::shared_ptr<std::ifstream>& source, const std::string& destFilename,
+                   const FileOperationTaskCallbackT& callback);
     void GetFilesInDirectory(const std::string& sourceDirectory, const GetFilesInfoTaskCallbackT& callback);
     void GetFileInfo(const std::string& sourceFile, const GetFilesInfoTaskCallbackT& callback);
-    void DeleteFileFunction(const std::string& filename, FileOperationTaskCallbackT callback);
+    void DeleteFileFunction(const std::string& filename, const FileOperationTaskCallbackT& callback);
 
     void AddStatisticsHandler(const StatisticsChangeHandler_t& changeHandler);
     void RemoveStatisticsHandler();

--- a/cpp/lib/src/master/MasterTasks.cpp
+++ b/cpp/lib/src/master/MasterTasks.cpp
@@ -31,25 +31,28 @@
 namespace opendnp3
 {
 
-MasterTasks::MasterTasks(const MasterParams& params,
-                         const Logger& logger,
-                         IMasterApplication& app,
-                         std::shared_ptr<ISOEHandler> SOEHandler)
-    : context(std::make_shared<TaskContext>()),
-      clearRestart(std::make_shared<ClearRestartTask>(context, app, logger)),
-      assignClass(std::make_shared<AssignClassTask>(context, app, RetryBehavior(params), logger)),
-      startupIntegrity(std::make_shared<StartupIntegrityPoll>(
-          context, app, SOEHandler, params.startupIntegrityClassMask, RetryBehavior(params), logger)),
-      eventScan(std::make_shared<EventScanTask>(
-          context, app, SOEHandler, params.eventScanOnEventsAvailableClassMask, logger)),
-      // optional tasks
-      disableUnsol(GetDisableUnsolTask(context, params, logger, app)),
-      enableUnsol(GetEnableUnsolTask(context, params, logger, app)),
-      timeSynchronization(GetTimeSyncTask(context, params, logger, app))
-{
-}
+MasterTasks::MasterTasks(
+    const MasterParams& params,
+    const Logger& logger,
+    IMasterApplication& app,
+    const std::shared_ptr<ISOEHandler>& SOEHandler
+)
+    : context(std::make_shared<TaskContext>())
+    , clearRestart(std::make_shared<ClearRestartTask>(context, app, logger))
+    , assignClass(std::make_shared<AssignClassTask>(context, app, RetryBehavior(params), logger))
+    , startupIntegrity(std::make_shared<StartupIntegrityPoll>(
+          context, app, SOEHandler, params.startupIntegrityClassMask, RetryBehavior(params), logger)
+    )
+    , eventScan(std::make_shared<EventScanTask>(
+          context, app, SOEHandler, params.eventScanOnEventsAvailableClassMask, logger)
+    )
+    // optional tasks
+    , disableUnsol(GetDisableUnsolTask(context, params, logger, app))
+    , enableUnsol(GetEnableUnsolTask(context, params, logger, app))
+    , timeSynchronization(GetTimeSyncTask(context, params, logger, app))
+{}
 
-void MasterTasks::Initialize(IMasterScheduler& scheduler, IMasterTaskRunner& runner)
+void MasterTasks::Initialize(IMasterScheduler& scheduler, IMasterTaskRunner& runner) const
 {
     for (auto& task :
          {clearRestart, assignClass, startupIntegrity, eventScan, enableUnsol, disableUnsol, timeSynchronization})
@@ -69,27 +72,27 @@ void MasterTasks::BindTask(const std::shared_ptr<IMasterTask>& task)
     boundTasks.push_back(task);
 }
 
-bool MasterTasks::DemandTimeSync()
+bool MasterTasks::DemandTimeSync() const
 {
-    return this->Demand(this->timeSynchronization);
+    return demand(this->timeSynchronization);
 }
 
-bool MasterTasks::DemandEventScan()
+bool MasterTasks::DemandEventScan() const
 {
-    return this->Demand(this->eventScan);
+    return demand(this->eventScan);
 }
 
-bool MasterTasks::DemandIntegrity()
+bool MasterTasks::DemandIntegrity() const
 {
-    return this->Demand(this->startupIntegrity);
+    return demand(this->startupIntegrity);
 }
 
-void MasterTasks::OnRestartDetected()
+void MasterTasks::OnRestartDetected() const
 {
-    this->Demand(this->clearRestart);
-    this->Demand(this->assignClass);
-    this->Demand(this->startupIntegrity);
-    this->Demand(this->enableUnsol);
+    demand(this->clearRestart);
+    demand(this->assignClass);
+    demand(this->startupIntegrity);
+    demand(this->enableUnsol);
 }
 
 std::shared_ptr<IMasterTask> MasterTasks::GetTimeSyncTask(const std::shared_ptr<TaskContext>& context,
@@ -97,19 +100,25 @@ std::shared_ptr<IMasterTask> MasterTasks::GetTimeSyncTask(const std::shared_ptr<
                                                           const Logger& logger,
                                                           IMasterApplication& application)
 {
+    const auto behavior = TaskBehavior::ImmediatePeriodic(
+           params.timeSyncPeriod,
+           params.taskRetryPeriod,
+           params.maxTaskRetryPeriod,
+           params.retryCount
+    );
     switch (params.timeSyncMode)
     {
-    case (TimeSyncMode::NonLAN): {
+    case TimeSyncMode::NonLAN: {
         if (params.timeSyncPeriod == TimeDuration::Max()) {
             return std::make_shared<SerialTimeSyncTask>(context, application, logger);
         }
-        return std::make_shared<SerialTimeSyncTask>(context, application, logger, params.timeSyncPeriod, params.taskRetryPeriod, params.maxTaskRetryPeriod);
+        return std::make_shared<SerialTimeSyncTask>(context, application, logger, behavior);
     }
-    case (TimeSyncMode::LAN): {
+    case TimeSyncMode::LAN: {
         if (params.timeSyncPeriod == TimeDuration::Max()) {
             return std::make_shared<LANTimeSyncTask>(context, application, logger);
         }
-        return std::make_shared<LANTimeSyncTask>(context, application, logger, params.timeSyncPeriod, params.taskRetryPeriod, params.maxTaskRetryPeriod);
+        return std::make_shared<LANTimeSyncTask>(context, application, logger, behavior);
     }
     default:
         return nullptr;
@@ -135,7 +144,7 @@ std::shared_ptr<IMasterTask> MasterTasks::GetDisableUnsolTask(const std::shared_
     return params.disableUnsolOnStartup
         ? std::make_shared<DisableUnsolicitedTask>(
               context, application,
-              TaskBehavior::SingleImmediateExecutionWithRetry(params.taskRetryPeriod, params.maxTaskRetryPeriod),
+              RetryBehavior(params),
               logger)
         : nullptr;
 }

--- a/cpp/lib/src/master/MasterTasks.h
+++ b/cpp/lib/src/master/MasterTasks.h
@@ -38,37 +38,34 @@ public:
     MasterTasks(const MasterParams& params,
                 const Logger& logger,
                 IMasterApplication& application,
-                std::shared_ptr<ISOEHandler> SOEHandler);
+                const std::shared_ptr<ISOEHandler>& SOEHandler);
 
-    void Initialize(IMasterScheduler& scheduler, IMasterTaskRunner& runner);
+    void Initialize(IMasterScheduler& scheduler, IMasterTaskRunner& runner) const;
 
-    bool DemandTimeSync();
-    bool DemandEventScan();
-    bool DemandIntegrity();
+    bool DemandTimeSync() const;
+    bool DemandEventScan() const;
+    bool DemandIntegrity() const;
 
-    void OnRestartDetected();
+    void OnRestartDetected() const;
 
     void BindTask(const std::shared_ptr<IMasterTask>& task);
 
     const std::shared_ptr<TaskContext> context;
 
 private:
-    bool Demand(const std::shared_ptr<IMasterTask>& task)
+    static bool demand(const std::shared_ptr<IMasterTask>& task)
     {
         if (task)
         {
             task->SetMinExpiration();
             return true;
         }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
-    inline static TaskBehavior RetryBehavior(const MasterParams& params)
+    static TaskBehavior RetryBehavior(const MasterParams& params)
     {
-        return TaskBehavior::SingleImmediateExecutionWithRetry(params.taskRetryPeriod, params.maxTaskRetryPeriod);
+        return TaskBehavior::SingleImmediateExecutionWithRetry(params.taskRetryPeriod, params.maxTaskRetryPeriod, params.retryCount);
     }
 
     const std::shared_ptr<IMasterTask> clearRestart;

--- a/cpp/lib/src/master/ReadFileTask.cpp
+++ b/cpp/lib/src/master/ReadFileTask.cpp
@@ -14,30 +14,35 @@
 namespace opendnp3
 {
 
-    ReadFileTask::ReadFileTask(const std::shared_ptr<TaskContext>& context,
+    ReadFileTask::ReadFileTask(
+        const std::shared_ptr<TaskContext>& context,
         IMasterApplication& app,
         const Logger& logger,
         std::string sourceFilename,
+        const TaskBehavior& taskBehavior,
         FileOperationTaskCallbackT taskCallback,
-        uint16_t rxSize)
-        : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(), logger, TaskConfig::Default()),
-          sourceFilename(std::move(sourceFilename)), output_file(std::ios::binary | std::ios::out), _rxSize(rxSize)
+        uint16_t rxSize
+    )
+        : IMasterTask(context, app, taskBehavior, logger, TaskConfig::Default())
+        , _sourceFilename(std::move(sourceFilename))
+        , _outputFile(std::ios::binary | std::ios::out)
+        , _rxSize(rxSize)
     {
-        callback = taskCallback ? std::move(taskCallback) : [](const FileOperationTaskResult& /**/) {};
+        _callback = taskCallback ? std::move(taskCallback) : [](const FileOperationTaskResult& /**/) {};
     }
 
     void ReadFileTask::Initialize()
     {
-        fileCommandStatus = Group70Var4();
-        fileTransportObject = Group70Var5();
+        _fileCommandStatus = Group70Var4();
+        _fileTransportObject = Group70Var5();
     }
 
     bool ReadFileTask::BuildRequest(APDURequest& request, uint8_t seq) {
-        switch (taskState) {
+        switch (_taskState) {
             case OPENING: {
                 logger.log(flags::DBG, __FILE__, "Attempting opening file");
                 Group70Var3 file;
-                file.filename = sourceFilename;
+                file.filename = _sourceFilename;
                 file.blockSize = _rxSize;
                 request.SetFunction(FunctionCode::OPEN_FILE);
                 request.SetControl(AppControlField::Request(seq));
@@ -45,17 +50,17 @@ namespace opendnp3
                 return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var3>(QualifierCode::FREE_FORMAT, file);
             }
             case READING: {
-                fileTransportObject.fileId = fileCommandStatus.fileId;
+                _fileTransportObject.fileId = _fileCommandStatus.fileId;
                 request.SetFunction(FunctionCode::READ);
                 request.SetControl(AppControlField::Request(seq));
                 auto writer = request.GetWriter();
-                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var5>(QualifierCode::FREE_FORMAT, fileTransportObject);
+                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var5>(QualifierCode::FREE_FORMAT, _fileTransportObject);
             }
             case CLOSING: {
                 request.SetFunction(FunctionCode::CLOSE_FILE);
                 request.SetControl(AppControlField::Request(seq));
                 auto writer = request.GetWriter();
-                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var4>(QualifierCode::FREE_FORMAT, fileCommandStatus);
+                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var4>(QualifierCode::FREE_FORMAT, _fileCommandStatus);
             }
             default:
                 return false;
@@ -64,14 +69,14 @@ namespace opendnp3
 
     IMasterTask::ResponseResult ReadFileTask::ProcessResponse(const APDUResponseHeader& response,
                                                               const ser4cpp::rseq_t& objects) {
-        switch (taskState) {
+        switch (_taskState) {
             case OPENING:
             case CLOSING:
                 return OnResponseStatusObject(response, objects);
             case READING:
                 return OnResponseReadFile(response, objects);
             default:
-                callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
+                _callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
                 return ResponseResult::ERROR_BAD_RESPONSE;
         }
     }
@@ -82,26 +87,26 @@ namespace opendnp3
             FileOperationHandler handler;
             const auto result = APDUParser::Parse(objects, handler, &logger);
             if (result != ParseResult::OK) {
-                callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
+                _callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
                 return ResponseResult::ERROR_BAD_RESPONSE;
             }
-            fileCommandStatus = handler.GetFileStatusObject();
+            _fileCommandStatus = handler.GetFileStatusObject();
             std::string s;
-            switch (fileCommandStatus.status) {
+            switch (_fileCommandStatus.status) {
                 case FileCommandStatus::SUCCESS:
-                    if (taskState == OPENING) {
-                        s = "Success opening file - \"" + sourceFilename + "\"";
+                    if (_taskState == OPENING) {
+                        s = "Success opening file - \"" + _sourceFilename + "\"";
                         logger.log(flags::DBG, __FILE__, s.c_str());
                         logger.log(flags::DBG, __FILE__, "Starting file reading...");
-                        taskState = READING;
+                        _taskState = READING;
                         return ResponseResult::OK_REPEAT;
                     }
                     logger.log(flags::DBG, __FILE__, "Successfully closed file");
-                    if (errorWhileReading) {
-                        callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
+                    if (_errorWhileReading) {
+                        _callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
                         return ResponseResult::ERROR_BAD_RESPONSE;
                     }
-                    callback(FileOperationTaskResult(TaskCompletion::SUCCESS, std::move(output_file)));
+                    _callback(FileOperationTaskResult(TaskCompletion::SUCCESS, std::move(_outputFile)));
                     return ResponseResult::OK_FINAL;
                 case FileCommandStatus::PERMISSION_DENIED:
                     logger.log(flags::DBG, __FILE__, "Permission denied");
@@ -110,18 +115,18 @@ namespace opendnp3
                     logger.log(flags::DBG, __FILE__, "Invalid mode");
                     break;
                 case FileCommandStatus::NOT_FOUND:
-                    s = "File - \"" + sourceFilename + "\" not found";
+                    s = "File - \"" + _sourceFilename + "\" not found";
                     logger.log(flags::DBG, __FILE__, s.c_str());
                     break;
                 case FileCommandStatus::FILE_LOCKED:
-                    s = "File - \"" + sourceFilename + "\" locked by another user";
+                    s = "File - \"" + _sourceFilename + "\" locked by another user";
                     logger.log(flags::DBG, __FILE__, s.c_str());
                     break;
                 case FileCommandStatus::OPEN_COUNT_EXCEEDED:
                     logger.log(flags::DBG, __FILE__, "Maximum amount of files opened");
                     break;
                 case FileCommandStatus::FILE_NOT_OPEN:
-                    s = "File - \"" + sourceFilename + "\" not opened";
+                    s = "File - \"" + _sourceFilename + "\" not opened";
                     logger.log(flags::DBG, __FILE__, s.c_str());
                     break;
                 case FileCommandStatus::INVALID_BLOCK_SIZE:
@@ -139,7 +144,7 @@ namespace opendnp3
             }
         }
 
-        callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
+        _callback(FileOperationTaskResult(TaskCompletion::FAILURE_BAD_RESPONSE));
         return ResponseResult::ERROR_BAD_RESPONSE;
     }
 
@@ -149,27 +154,27 @@ namespace opendnp3
             FileOperationHandler handler;
             const auto result = APDUParser::Parse(objects, handler, &logger);
             if (result != ParseResult::OK) {
-                errorWhileReading = true;
-                taskState = CLOSING;
+                _errorWhileReading = true;
+                _taskState = CLOSING;
                 return ResponseResult::OK_REPEAT;
             }
 
-            fileTransportObject = handler.GetFileTransferObject();
-            const auto *data = static_cast<const uint8_t*>(fileTransportObject.data);
-            output_file.write(reinterpret_cast<const char *>(data), fileTransportObject.data.length());
-            fileTransportObject.data.make_empty();
-            fileTransportObject.blockNumber += 1;
-            if (fileTransportObject.isLastBlock) {
-                const std::string s = "File - \"" + sourceFilename +"\" successfully received";
+            _fileTransportObject = handler.GetFileTransferObject();
+            const auto *data = static_cast<const uint8_t*>(_fileTransportObject.data);
+            _outputFile.write(reinterpret_cast<const char *>(data), _fileTransportObject.data.length());
+            _fileTransportObject.data.make_empty();
+            _fileTransportObject.blockNumber += 1;
+            if (_fileTransportObject.isLastBlock) {
+                const std::string s = "File - \"" + _sourceFilename +"\" successfully received";
                 logger.log(flags::DBG, __FILE__, s.c_str());
-                taskState = CLOSING;
+                _taskState = CLOSING;
             }
 
             return ResponseResult::OK_REPEAT;
         }
 
-        errorWhileReading = true;
-        taskState = CLOSING;
+        _errorWhileReading = true;
+        _taskState = CLOSING;
         return ResponseResult::OK_REPEAT;
     }
 } // namespace opendnp3

--- a/cpp/lib/src/master/ReadFileTask.h
+++ b/cpp/lib/src/master/ReadFileTask.h
@@ -16,8 +16,15 @@ namespace opendnp3
     {
 
     public:
-        ReadFileTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger,
-                     std::string sourceFilename, FileOperationTaskCallbackT taskCallback, uint16_t rxSize);
+        ReadFileTask(
+            const std::shared_ptr<TaskContext>& context,
+            IMasterApplication& app,
+            const Logger& logger,
+            std::string sourceFilename,
+            const TaskBehavior& taskBehavior,
+            FileOperationTaskCallbackT taskCallback,
+            uint16_t rxSize
+        );
 
         char const* Name() const final
         {
@@ -61,14 +68,14 @@ namespace opendnp3
         void Initialize() final;
 
     private:
-        FileOperationTaskState taskState{ OPENING };
-        std::string sourceFilename;
-        std::ostringstream output_file;
-        Group70Var4 fileCommandStatus;
-        Group70Var5 fileTransportObject;
-        FileOperationTaskCallbackT callback;
+        FileOperationTaskState _taskState{ OPENING };
+        std::string _sourceFilename;
+        std::ostringstream _outputFile;
+        Group70Var4 _fileCommandStatus;
+        Group70Var5 _fileTransportObject;
+        FileOperationTaskCallbackT _callback;
         uint16_t _rxSize;
-        bool errorWhileReading = false;
+        bool _errorWhileReading{ false };
     };
 
 } // namespace opendnp3

--- a/cpp/lib/src/master/RestartOperationTask.cpp
+++ b/cpp/lib/src/master/RestartOperationTask.cpp
@@ -29,18 +29,20 @@
 namespace opendnp3
 {
 
-RestartOperationTask::RestartOperationTask(const std::shared_ptr<TaskContext>& context,
-                                           IMasterApplication& app,
-                                           const Timestamp& startTimeout,
-                                           RestartType operationType,
-                                           RestartOperationCallbackT callback,
-                                           const Logger& logger,
-                                           const TaskConfig& config)
-    : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(startTimeout), logger, config),
-      function((operationType == RestartType::COLD) ? FunctionCode::COLD_RESTART : FunctionCode::WARM_RESTART),
-      callback(std::move(callback))
-{
-}
+RestartOperationTask::RestartOperationTask(
+    const std::shared_ptr<TaskContext>& context,
+    IMasterApplication& app,
+    const Timestamp& startTimeout,
+    RestartType operationType,
+    RestartOperationCallbackT callback,
+    const Logger& logger,
+    const TaskConfig& config,
+    const TaskBehavior& taskBehavior
+)
+    : IMasterTask(context, app, taskBehavior, logger, config)
+    , function((operationType == RestartType::COLD) ? FunctionCode::COLD_RESTART : FunctionCode::WARM_RESTART)
+    , callback(std::move(callback))
+{}
 
 bool RestartOperationTask::BuildRequest(APDURequest& request, uint8_t seq)
 {

--- a/cpp/lib/src/master/RestartOperationTask.h
+++ b/cpp/lib/src/master/RestartOperationTask.h
@@ -34,13 +34,16 @@ class RestartOperationTask final : public IMasterTask, private IAPDUHandler
 {
 
 public:
-    RestartOperationTask(const std::shared_ptr<TaskContext>& context,
-                         IMasterApplication& app,
-                         const Timestamp& startTimeout,
-                         RestartType operationType,
-                         RestartOperationCallbackT callback,
-                         const Logger& logger,
-                         const TaskConfig& config);
+    RestartOperationTask(
+        const std::shared_ptr<TaskContext>& context,
+        IMasterApplication& app,
+        const Timestamp& startTimeout,
+        RestartType operationType,
+        RestartOperationCallbackT callback,
+        const Logger& logger,
+        const TaskConfig& config,
+        const TaskBehavior& taskBehavior
+    );
 
     bool BuildRequest(APDURequest& request, uint8_t seq) override;
 

--- a/cpp/lib/src/master/SerialTimeSyncTask.cpp
+++ b/cpp/lib/src/master/SerialTimeSyncTask.cpp
@@ -36,13 +36,13 @@ SerialTimeSyncTask::SerialTimeSyncTask(const std::shared_ptr<TaskContext>& conte
 {
 }
 
-SerialTimeSyncTask::SerialTimeSyncTask(const std::shared_ptr<TaskContext>& context,
-                                       IMasterApplication& app,
-                                       const Logger& logger,
-                                       TimeDuration period,
-                                       TimeDuration mixRetryTimeout,
-                                       TimeDuration maxRetryTimeout)
-    : IMasterTask(context, app, TaskBehavior::ImmediatePeriodic(period, mixRetryTimeout, maxRetryTimeout), logger, TaskConfig::Default()), delay(-1)
+SerialTimeSyncTask::SerialTimeSyncTask(
+    const std::shared_ptr<TaskContext>& context,
+    IMasterApplication& app,
+    const Logger& logger,
+    const TaskBehavior& taskBehavior
+)
+    : IMasterTask(context, app, taskBehavior, logger, TaskConfig::Default()), delay(-1)
 { }
 
 void SerialTimeSyncTask::Initialize()

--- a/cpp/lib/src/master/SerialTimeSyncTask.h
+++ b/cpp/lib/src/master/SerialTimeSyncTask.h
@@ -32,8 +32,12 @@ class SerialTimeSyncTask : public IMasterTask
 
 public:
     SerialTimeSyncTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger);
-    SerialTimeSyncTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger,
-                       TimeDuration period, TimeDuration mixRetryTimeout, TimeDuration maxRetryTimeout);
+    SerialTimeSyncTask(
+        const std::shared_ptr<TaskContext>& context,
+        IMasterApplication& app,
+        const Logger& logger,
+        const TaskBehavior& taskBehavior
+    );
 
     char const* Name() const final
     {

--- a/cpp/lib/src/master/TaskBehavior.cpp
+++ b/cpp/lib/src/master/TaskBehavior.cpp
@@ -20,69 +20,83 @@
 
 #include "TaskBehavior.h"
 
-#include <limits>
-
 namespace opendnp3
 {
 
-TaskBehavior TaskBehavior::SingleExecutionNoRetry()
-{
-    return SingleExecutionNoRetry(Timestamp::Max()); // no start expiration
+TaskBehavior TaskBehavior::SingleExecutionWithRetry(
+    const Timestamp& startExpiration,
+    const TimeDuration& minRetryDelay,
+    const TimeDuration& maxRetryDelay,
+    const NumRetries& retryCount
+) {
+    return {
+        TimeDuration::Min(), // not periodic
+        Timestamp::Min(),    // run immediately
+        minRetryDelay,
+        maxRetryDelay,
+        startExpiration,
+        retryCount
+    };
 }
 
-TaskBehavior TaskBehavior::SingleExecutionNoRetry(const Timestamp& startExpiration)
-{
-    return TaskBehavior(TimeDuration::Min(), // not periodic
-                        Timestamp::Min(),    // run immediately
-                        TimeDuration::Max(), TimeDuration::Max(), startExpiration,
-                        NumRetries::Fixed(0));
+TaskBehavior TaskBehavior::ImmediatePeriodic(
+    const TimeDuration& period,
+    const TimeDuration& minRetryDelay,
+    const TimeDuration& maxRetryDelay,
+    const NumRetries&   retryCount
+) {
+    return {
+        period,
+        Timestamp::Min(), // run immediately
+        minRetryDelay,
+        maxRetryDelay,
+        Timestamp::Max(), // no start expiration
+        retryCount
+    };
 }
 
-TaskBehavior TaskBehavior::ImmediatePeriodic(const TimeDuration& period,
-                                             const TimeDuration& minRetryDelay,
-                                             const TimeDuration& maxRetryDelay,
-                                             const NumRetries&   retryCount)
-{
-    return TaskBehavior(period,
-                        Timestamp::Min(), // run immediately
-                        minRetryDelay, maxRetryDelay,
-                        Timestamp::Max(), // no start expiraion
-                        retryCount
-    );
-}
-
-TaskBehavior TaskBehavior::SingleImmediateExecutionWithRetry(const TimeDuration& minRetryDelay,
-                                                             const TimeDuration& maxRetryDelay,
-                                                             const NumRetries&   retryCount)
-{
-    return TaskBehavior(TimeDuration::Min(), // not periodic
-                        Timestamp::Min(),    // run immediatey
-                        minRetryDelay, maxRetryDelay, Timestamp::Max(),
-                        retryCount);
+TaskBehavior TaskBehavior::SingleImmediateExecutionWithRetry(
+    const TimeDuration& minRetryDelay,
+    const TimeDuration& maxRetryDelay,
+    const NumRetries&   retryCount
+) {
+    return {
+        TimeDuration::Min(), // not periodic
+        Timestamp::Min(),    // run immediately
+        minRetryDelay,
+        maxRetryDelay,
+        Timestamp::Max(),
+        retryCount
+    };
 }
 
 TaskBehavior TaskBehavior::ReactsToIINOnly()
 {
-    return TaskBehavior(TimeDuration::Min(), // not periodic
-                        Timestamp::Max(),    // only run when needed
-                        TimeDuration::Max(), // never retry
-                        TimeDuration::Max(), Timestamp::Max(),
-                        NumRetries::Fixed(0));
+    return {
+        TimeDuration::Min(), // not periodic
+        Timestamp::Max(),    // only run when needed
+        TimeDuration::Max(), // never retry
+        TimeDuration::Max(),
+        Timestamp::Max(),
+        NumRetries::Fixed(0)
+    };
 }
 
-TaskBehavior::TaskBehavior(const TimeDuration& period,
-                           const Timestamp& expiration,
-                           const TimeDuration& minRetryDelay,
-                           const TimeDuration& maxRetryDelay,
-                           const Timestamp& startExpiration,
-                           const NumRetries& retryCount)
-    : period(period),
-      minRetryDelay(minRetryDelay),
-      maxRetryDelay(maxRetryDelay),
-      startExpiration(startExpiration),
-      expiration(expiration),
-      currentRetryDelay(minRetryDelay),
-      _retryCount(retryCount)
+TaskBehavior::TaskBehavior(
+    const TimeDuration& period,
+    const Timestamp& expiration,
+    const TimeDuration& minRetryDelay,
+    const TimeDuration& maxRetryDelay,
+    const Timestamp& startExpiration,
+    const NumRetries& retryCount
+)
+    : period(period)
+    , minRetryDelay(minRetryDelay)
+    , maxRetryDelay(maxRetryDelay)
+    , startExpiration(startExpiration)
+    , expiration(expiration)
+    , currentRetryDelay(minRetryDelay)
+    , _retryCount(retryCount)
 {
 }
 
@@ -130,13 +144,13 @@ void TaskBehavior::DelayByPeriod(const Timestamp& now)
     _retryCount.Reset();
 }
 
-TimeDuration TaskBehavior::CalcNextRetryTimeout()
+TimeDuration TaskBehavior::CalcNextRetryTimeout() const
 {
     if (_retryCount.IsFixed()) {
         return this->minRetryDelay;
     }
     const auto doubled = this->currentRetryDelay.Double();
-    return (doubled > this->maxRetryDelay) ? this->maxRetryDelay : doubled;
+    return doubled > this->maxRetryDelay ? this->maxRetryDelay : doubled;
 }
 
 } // namespace opendnp3

--- a/cpp/lib/src/master/TaskBehavior.h
+++ b/cpp/lib/src/master/TaskBehavior.h
@@ -57,9 +57,14 @@ class TaskBehavior
 {
 
 public:
-    static TaskBehavior SingleExecutionNoRetry();
+    TaskBehavior() = delete;
 
-    static TaskBehavior SingleExecutionNoRetry(const Timestamp& startExpiration);
+    static TaskBehavior SingleExecutionWithRetry(
+        const Timestamp& startExpiration,
+        const TimeDuration& minRetryDelay,
+        const TimeDuration& maxRetryDelay,
+        const NumRetries& retryCount = NumRetries::Infinite()
+    );
 
     static TaskBehavior ImmediatePeriodic(const TimeDuration& period,
                                           const TimeDuration& minRetryDelay,
@@ -112,9 +117,7 @@ public:
     void DelayByPeriod(const Timestamp& now);
 
 private:
-    TimeDuration CalcNextRetryTimeout();
-
-    TaskBehavior() = delete;
+    TimeDuration CalcNextRetryTimeout() const;
 
     TaskBehavior(const TimeDuration& period,
                  const Timestamp& expiration,

--- a/cpp/lib/src/master/WriteFileTask.cpp
+++ b/cpp/lib/src/master/WriteFileTask.cpp
@@ -13,36 +13,42 @@
 
 namespace opendnp3
 {
-    WriteFileTask::WriteFileTask(const std::shared_ptr<TaskContext>& context,
+    WriteFileTask::WriteFileTask(
+        const std::shared_ptr<TaskContext>& context,
         IMasterApplication& app,
         const Logger& logger,
         std::shared_ptr<std::ifstream> source,
-        std::string destFilename, uint16_t txSize,
-        FileOperationTaskCallbackT taskCallback)
-        : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(), logger, TaskConfig::Default()),
-          input_file(std::move(source)), destFilename(std::move(destFilename)), _txSize(txSize)
+        std::string destFilename,
+        uint16_t txSize,
+        const TaskBehavior& taskBehavior,
+        FileOperationTaskCallbackT taskCallback
+    )
+        : IMasterTask(context, app, taskBehavior, logger, TaskConfig::Default())
+        , _inputFile(std::move(source))
+        , _destFilename(std::move(destFilename))
+        , _txSize(txSize)
     {
-        callback = taskCallback ? std::move(taskCallback) : [](const FileOperationTaskResult& /**/) {};
-        auto fsize = input_file->tellg();
-        input_file->seekg(0, std::ios::end);
-        fsize = input_file->tellg() - fsize;
-        input_file->seekg(0);
-        inputFileSize = static_cast<uint32_t>(fsize);
+        _callback = taskCallback ? std::move(taskCallback) : [](const FileOperationTaskResult& /**/) {};
+        auto fsize = _inputFile->tellg();
+        _inputFile->seekg(0, std::ios::end);
+        fsize = _inputFile->tellg() - fsize;
+        _inputFile->seekg(0);
+        _inputFileSize = static_cast<uint32_t>(fsize);
     }
 
     void WriteFileTask::Initialize()
     {
-        fileCommandStatus = Group70Var4();
-        fileTransportObject = Group70Var5(FileOpeningMode::WRITE);
+        _fileCommandStatus = Group70Var4();
+        _fileTransportObject = Group70Var5(FileOpeningMode::WRITE);
     }
 
     bool WriteFileTask::BuildRequest(APDURequest& request, uint8_t seq) {
-        switch (taskState) {
+        switch (_taskState) {
             case OPENING: {
                 logger.log(flags::DBG, __FILE__, "Attempting opening file");
                 Group70Var3 file(FileOpeningMode::WRITE);
-                file.filename = destFilename;
-                file.filesize = inputFileSize;
+                file.filename = _destFilename;
+                file.filesize = _inputFileSize;
                 file.blockSize = _txSize;
                 request.SetFunction(FunctionCode::OPEN_FILE);
                 request.SetControl(AppControlField::Request(seq));
@@ -50,21 +56,21 @@ namespace opendnp3
                 return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var3>(QualifierCode::FREE_FORMAT, file);
             }
             case WRITING: {
-                fileTransportObject.fileId = fileCommandStatus.fileId;
-                const uint32_t size = std::min(static_cast<uint32_t>(fileCommandStatus.blockSize), inputFileSize);
-                fileTransportObject.data.make_empty();
+                _fileTransportObject.fileId = _fileCommandStatus.fileId;
+                const uint32_t size = std::min(static_cast<uint32_t>(_fileCommandStatus.blockSize), _inputFileSize);
+                _fileTransportObject.data.make_empty();
                 char* data = new char[size + 1];
                 data[size] = 0;
-                input_file->read(data, size);
-                fileTransportObject.data = ser4cpp::rseq_t(reinterpret_cast<uint8_t const*>(data), size);
-                inputFileSize -= size;
-                if (inputFileSize == 0) {
-                    fileTransportObject.isLastBlock = true;
+                _inputFile->read(data, size);
+                _fileTransportObject.data = ser4cpp::rseq_t(reinterpret_cast<uint8_t const*>(data), size);
+                _inputFileSize -= size;
+                if (_inputFileSize == 0) {
+                    _fileTransportObject.isLastBlock = true;
                 }
                 request.SetFunction(FunctionCode::WRITE);
                 request.SetControl(AppControlField::Request(seq));
                 auto writer = request.GetWriter();
-                const auto res = writer.WriteSingleValue<ser4cpp::UInt8, Group70Var5>(QualifierCode::FREE_FORMAT, fileTransportObject);
+                const auto res = writer.WriteSingleValue<ser4cpp::UInt8, Group70Var5>(QualifierCode::FREE_FORMAT, _fileTransportObject);
                 delete[] data;
                 return res;
             }
@@ -72,7 +78,7 @@ namespace opendnp3
                 request.SetFunction(FunctionCode::CLOSE_FILE);
                 request.SetControl(AppControlField::Request(seq));
                 auto writer = request.GetWriter();
-                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var4>(QualifierCode::FREE_FORMAT, fileCommandStatus);
+                return writer.WriteSingleValue<ser4cpp::UInt8, Group70Var4>(QualifierCode::FREE_FORMAT, _fileCommandStatus);
             }
             default:
                 return false;
@@ -81,7 +87,7 @@ namespace opendnp3
 
     IMasterTask::ResponseResult WriteFileTask::ProcessResponse(const APDUResponseHeader& response,
                                                               const ser4cpp::rseq_t& objects) {
-        switch (taskState) {
+        switch (_taskState) {
             case OPENING:
             case CLOSING:
                 return OnResponseStatusObject(response, objects);
@@ -100,18 +106,18 @@ namespace opendnp3
             if (result != ParseResult::OK) {
                 return ResponseResult::ERROR_BAD_RESPONSE;
             }
-            fileCommandStatus = handler.GetFileStatusObject();
+            _fileCommandStatus = handler.GetFileStatusObject();
             std::string s;
-            switch (fileCommandStatus.status) {
+            switch (_fileCommandStatus.status) {
             case FileCommandStatus::SUCCESS:
-                if (taskState == OPENING) {
+                if (_taskState == OPENING) {
                     logger.log(flags::DBG, __FILE__, "Success opening file");
                     logger.log(flags::DBG, __FILE__, "Starting file writing...");
-                    taskState = WRITING;
+                    _taskState = WRITING;
                     return ResponseResult::OK_REPEAT;
                 }
                 logger.log(flags::DBG, __FILE__, "Successfully closed file");
-                if (errorWhileWriting) {
+                if (_errorWhileWriting) {
                     return ResponseResult::ERROR_BAD_RESPONSE;
                 }
                 return ResponseResult::OK_FINAL;
@@ -122,18 +128,18 @@ namespace opendnp3
                 logger.log(flags::DBG, __FILE__, "Invalid mode");
                 break;
             case FileCommandStatus::NOT_FOUND:
-                s = "File - \"" + destFilename + "\" not found";
+                s = "File - \"" + _destFilename + "\" not found";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::FILE_LOCKED:
-                s = "File - \"" + destFilename + "\" locked by another user";
+                s = "File - \"" + _destFilename + "\" locked by another user";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::OPEN_COUNT_EXCEEDED:
                 logger.log(flags::DBG, __FILE__, "Maximum amount of files opened");
                 break;
             case FileCommandStatus::FILE_NOT_OPEN:
-                s = "File - \"" + destFilename + "\" not opened";
+                s = "File - \"" + _destFilename + "\" not opened";
                 logger.log(flags::DBG, __FILE__, s.c_str());
                 break;
             case FileCommandStatus::INVALID_BLOCK_SIZE:
@@ -163,17 +169,17 @@ namespace opendnp3
                 return ResponseResult::ERROR_BAD_RESPONSE;
             }
 
-            fileTransportStatusObject = handler.GetFileTransferStatusObject();
-            switch (fileTransportStatusObject.status) {
+            _fileTransportStatusObject = handler.GetFileTransferStatusObject();
+            switch (_fileTransportStatusObject.status) {
                 case FileTransportStatus::SUCCESS:
-                    if (fileTransportObject.isLastBlock) {
-                        const std::string s = "File - \"" + destFilename +"\"  had been written successfully";
+                    if (_fileTransportObject.isLastBlock) {
+                        const std::string s = "File - \"" + _destFilename +"\"  had been written successfully";
                         logger.log(flags::DBG, __FILE__, s.c_str());
-                        taskState = CLOSING;
+                        _taskState = CLOSING;
                         return ResponseResult::OK_REPEAT;
                     }
 
-                    fileTransportObject.blockNumber = fileTransportStatusObject.blockNumber + 1;
+                    _fileTransportObject.blockNumber = _fileTransportStatusObject.blockNumber + 1;
                     return ResponseResult::OK_REPEAT;
                 case FileTransportStatus::LOST_COM:
                     logger.log(flags::DBG, __FILE__, "Communication lost");
@@ -183,7 +189,7 @@ namespace opendnp3
                     break;
                 case FileTransportStatus::HANDLE_TIMEOUT:
                     logger.log(flags::DBG, __FILE__, "File handle expired, reopening file");
-                    taskState = OPENING;
+                    _taskState = OPENING;
                     return ResponseResult::OK_REPEAT;
                 case FileTransportStatus::BUFFER_OVERFLOW:
                     logger.log(flags::DBG, __FILE__, "Outstation buffer overflow while writing data");
@@ -199,8 +205,8 @@ namespace opendnp3
             }
         }
 
-        errorWhileWriting = true;
-        taskState = CLOSING;
+        _errorWhileWriting = true;
+        _taskState = CLOSING;
         return ResponseResult::OK_REPEAT;
     }
 } // namespace opendnp3

--- a/cpp/lib/src/master/WriteFileTask.h
+++ b/cpp/lib/src/master/WriteFileTask.h
@@ -16,9 +16,16 @@ namespace opendnp3
     {
 
     public:
-        WriteFileTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, const Logger& logger,
-                      std::shared_ptr<std::ifstream> source, std::string destFilename, uint16_t txSize,
-                      FileOperationTaskCallbackT taskCallback);
+        WriteFileTask(
+            const std::shared_ptr<TaskContext>& context,
+            IMasterApplication& app,
+            const Logger& logger,
+            std::shared_ptr<std::ifstream> source,
+            std::string destFilename,
+            uint16_t txSize,
+            const TaskBehavior& taskBehavior,
+            FileOperationTaskCallbackT taskCallback
+        );
 
         char const* Name() const final
         {
@@ -62,16 +69,16 @@ namespace opendnp3
         void Initialize() final;
 
     private:
-        FileOperationTaskState taskState{ OPENING };
-        std::shared_ptr<std::ifstream> input_file;
-        uint32_t inputFileSize;
-        std::string destFilename;
-        Group70Var4 fileCommandStatus;
-        Group70Var5 fileTransportObject;
-        Group70Var6 fileTransportStatusObject;
-        FileOperationTaskCallbackT callback;
+        FileOperationTaskState _taskState{ OPENING };
+        std::shared_ptr<std::ifstream> _inputFile;
+        uint32_t _inputFileSize;
+        std::string _destFilename;
+        Group70Var4 _fileCommandStatus;
+        Group70Var5 _fileTransportObject;
+        Group70Var6 _fileTransportStatusObject;
+        FileOperationTaskCallbackT _callback;
         uint16_t _txSize;
-        bool errorWhileWriting = false;
+        bool _errorWhileWriting{ false };
     };
 
 } // namespace opendnp3


### PR DESCRIPTION
- made sure that all tasks respect retryCount config param
- implemented separate indicator for task timeout (on both primary and backup channels) and general channel opening failure
- made some small stylistic changes